### PR TITLE
CI hardening: pin Plugin Check WordPress version, add PHPStan

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,8 @@
 /composer.json
 /composer.lock
 /phpcs.xml.dist
+/phpstan.neon.dist
+/phpstan
 /.phpcs-cache
 /phpunit.xml.dist
 /.phpunit.cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,26 @@ jobs:
       - name: Check the .pot is up to date
         run: WP_CLI=/tmp/wp-cli.phar bin/check-pot.sh
 
+  static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      # WordPress stubs are large; the default 128M limit crashes the run.
+      - name: PHPStan
+        run: composer analyse
+
   lint-test:
     name: Lint & Test (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
@@ -86,6 +106,13 @@ jobs:
         uses: WordPress/plugin-check-action@v1
         with:
           build-dir: ./build/onsite-spam-guard
+          # Pinned rather than left at `latest`. On 2026-08-12 `latest`
+          # resolved to a WordPress version whose wordpress-develop tag had
+          # not yet propagated, and the job failed with
+          # "fatal: couldn't find remote ref 7.0.4" — indistinguishable from
+          # a real failure at a glance. Keep this in step with the readme's
+          # `Tested up to`, so the check runs against the version we claim.
+          wp-version: '7.1'
           # The plugin intentionally uses direct queries against its own
           # custom log table; those are warnings, not errors. Fail the job
           # only on errors so real regressions still block.

--- a/admin/class-spam-logs-list-table.php
+++ b/admin/class-spam-logs-list-table.php
@@ -72,6 +72,8 @@ final class Spam_Logs_List_Table extends \WP_List_Table {
 
 	/**
 	 * Checkbox column.
+	 *
+	 * @param \stdClass $item Log row.
 	 */
 	public function column_cb( $item ): string {
 		return sprintf(
@@ -82,6 +84,8 @@ final class Spam_Logs_List_Table extends \WP_List_Table {
 
 	/**
 	 * Content column with row actions.
+	 *
+	 * @param \stdClass $item Log row.
 	 */
 	public function column_content( $item ): string {
 		$content = esc_html( wp_trim_words( $item->content, 15, '…' ) );
@@ -111,6 +115,9 @@ final class Spam_Logs_List_Table extends \WP_List_Table {
 
 	/**
 	 * Default column renderer.
+	 *
+	 * @param \stdClass $item        Log row.
+	 * @param string    $column_name Column being rendered.
 	 */
 	public function column_default( $item, $column_name ): string {
 		return match ( $column_name ) {
@@ -127,6 +134,8 @@ final class Spam_Logs_List_Table extends \WP_List_Table {
 
 	/**
 	 * User-agent column — truncated, with the full value in a tooltip.
+	 *
+	 * @param \stdClass $item Log row.
 	 */
 	public function column_user_agent( $item ): string {
 		$agent = (string) $item->user_agent;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"phpunit/phpunit": "^10.5"
+		"phpunit/phpunit": "^10.5",
+		"phpstan/phpstan": "^2.2",
+		"szepeviktor/phpstan-wordpress": "^2.0"
 	},
 	"config": {
 		"allow-plugins": {
@@ -21,6 +23,7 @@
 		"lint": "phpcs",
 		"lint:fix": "phpcbf",
 		"test": "phpunit",
+		"analyse": "phpstan analyse --memory-limit=1G",
 		"check-versions": "bin/check-versions.sh",
 		"build": "bin/build-dist.sh"
 	}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a673413a30e61ec5871bf05ee1a5e836",
+    "content-hash": "8ea0c6a7a061187321cff17faa0555b5",
     "packages": [],
     "packages-dev": [
         {
@@ -338,6 +338,58 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+            },
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -726,6 +778,70 @@
                 }
             ],
             "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.8",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2190,6 +2306,69 @@
             "time": "2025-11-04T16:30:35+00:00"
         },
         {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
+            },
+            "time": "2025-09-14T02:58:22+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -2312,7 +2491,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/includes/core/class-database-manager.php
+++ b/includes/core/class-database-manager.php
@@ -121,7 +121,7 @@ final class Database_Manager {
 	 * @param string $orderby  Column to sort by.
 	 * @param string $order    ASC or DESC.
 	 * @param array  $filters  Optional guard/context filters.
-	 * @return array Array of row objects.
+	 * @return \stdClass[] Row objects.
 	 */
 	public static function get_logs( int $per_page = 20, int $offset = 0, string $orderby = 'blocked_at', string $order = 'DESC', array $filters = [] ): array {
 		global $wpdb;

--- a/includes/core/class-guard-runner.php
+++ b/includes/core/class-guard-runner.php
@@ -45,8 +45,7 @@ final class Guard_Runner {
 				continue;
 			}
 
-			$class = $guard_map[ $slug ];
-			/** @var Guard_Interface $instance */
+			$class    = $guard_map[ $slug ];
 			$instance = new $class( $slug, $def );
 
 			self::$guards[] = $instance;

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -38,7 +38,10 @@ final class WooCommerce {
 		add_action( 'woocommerce_new_comment', [ __CLASS__, 'check_review' ], 1 );
 
 		// Also inject honeypot into the review form.
-		add_action( 'woocommerce_product_review_comment_form_args', [ __CLASS__, 'add_form_fields' ] );
+		// A filter, not an action: WooCommerce runs it through apply_filters(),
+		// so a callback registered with add_action() would have its return
+		// value discarded and any change to the args silently dropped.
+		add_filter( 'woocommerce_product_review_comment_form_args', [ __CLASS__, 'add_form_fields' ] );
 	}
 
 	/**
@@ -66,9 +69,9 @@ final class WooCommerce {
 		}
 
 		$data = [
-			'content'                            => $comment->comment_content ?? '',
-			'author'                             => $comment->comment_author ?? '',
-			'email'                              => $comment->comment_author_email ?? '',
+			'content'                            => $comment->comment_content,
+			'author'                             => $comment->comment_author,
+			'email'                              => $comment->comment_author_email,
 			// JS-injected fields from a public form submission; there is no
 			// plugin nonce to verify at this stage (that is the optional Nonce
 			// guard's job downstream). Values are sanitized on read.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,20 @@
+includes:
+	- vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+parameters:
+	level: 5
+
+	bootstrapFiles:
+		- phpstan/constants.php
+
+	paths:
+		- includes
+		- admin
+		- onsite-spam-guard.php
+		- uninstall.php
+
+	# tests/ deliberately redefines WordPress functions as lightweight stubs so
+	# the suite can run without a WordPress install. Analysing it would report
+	# those redefinitions as conflicts with the real signatures.
+	excludePaths:
+		- tests

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin constants for static analysis only.
+ *
+ * They are defined at runtime in onsite-spam-guard.php, but PHPStan cannot
+ * rely on that file's top-level `define()` calls because the direct-access
+ * guard above them may terminate execution. This file is never shipped — it
+ * exists solely as a PHPStan bootstrap.
+ *
+ * @package Simple_Spam_Shield
+ */
+
+define( 'SIMPLE_SPAM_SHIELD_VERSION', '0.0.0' );
+define( 'SIMPLE_SPAM_SHIELD_FILE', __FILE__ );
+define( 'SIMPLE_SPAM_SHIELD_DIR', dirname( __DIR__ ) . '/' );
+define( 'SIMPLE_SPAM_SHIELD_URL', 'https://example.org/wp-content/plugins/onsite-spam-guard/' );


### PR DESCRIPTION
Closes #5. Closes #10.

Opened as a PR rather than pushed straight to `main` because the `wp-version` input is documented only as accepting `latest` or `trunk`. The earlier failure showed the action builds a git ref from the value, so a numeric version should work — but that is an inference, and this is the run that proves it.

**#5** pins `wp-version: '7.1'`, matching the readme's `Tested up to`.

**#10** adds PHPStan at level 5 with the WordPress stubs. Level 6 reports 57 findings (almost all array-type specificity), so it is left as a future ratchet.

PHPStan earned its place on the first run: `woocommerce_product_review_comment_form_args` is a **filter**, but was registered with `add_action()`, which discards the return value. The callback is a pass-through today so nothing was broken in practice — but any field injection added there later would have vanished silently.

Local gate is green: PHPStan clean, 78 tests, PHPCS clean, version metadata consistent, translation template up to date, and a clean `composer install` from the lock verified.

Watch for: the **Plugin Check** job (does the pinned version resolve?) and **Static analysis** (does it pass on Linux — the last shell tooling I added was macOS-specific).