### PR TITLE
1.2.1: fix IPv6 allowlist, transient cleanup, honeypot field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ The user-facing changelog shipped to WordPress.org lives in the
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-21
+
+### Fixed
+- Allowlist CIDR matching ignored IPv6 entirely. `ip_in_cidr()` used
+  `ip2long()` and 32-bit arithmetic, so a range like `2001:db8::/32` silently
+  never matched — no warning, no log entry, no effect — in the very control
+  that exists to rescue legitimate visitors from false positives. It now
+  compares the packed binary forms from `inet_pton()`, handling both address
+  families through one path, and rejects mismatched families and malformed
+  prefixes rather than over-matching. The allowlist previously had no test
+  coverage at all; it now has 11 cases exercised through the public path.
+- The uninstall routine removed duplicate-detection transients but not the
+  rate-limit transients added in 1.2.0, leaving rows in `wp_options` after
+  deletion. It now matches on the shared prefix, so families added later are
+  covered too. The `LIKE` patterns also now escape `_`, which is a
+  single-character wildcard in SQL and made the old patterns looser than they
+  appeared.
+- The honeypot guard read its field name from `config/guards.json`, but the
+  rendered markup, the front-end script and all eight integration reads
+  hardcoded it. Changing the configured value made the guard look for a field
+  nothing produced, silently disabling the highest-weight guard. The name is
+  now a constant; see #23 for wiring it through properly, which would allow a
+  per-site randomised name.
+
 ## [1.2.0] - 2026-08-21
 
 ### Added
@@ -139,7 +163,8 @@ Initial release.
   their own forms: `simple_spam_shield_check()`,
   `simple_spam_shield_protect_selector()`, and `simple_spam_shield_field_markup()`.
 
-[Unreleased]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jwincek/onsite-spam-guard/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/jwincek/onsite-spam-guard/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/jwincek/onsite-spam-guard/compare/v1.1.1...v1.1.2

--- a/config/guards.json
+++ b/config/guards.json
@@ -4,7 +4,6 @@
 			"label": "Honeypot field",
 			"description": "Adds a hidden field that bots fill in but humans never see.",
 			"enabled_by_default": true,
-			"field_name": "simple_spam_shield_website_url",
 			"weight": 100
 		},
 		"time_gate": {

--- a/includes/core/class-guard-runner.php
+++ b/includes/core/class-guard-runner.php
@@ -166,26 +166,61 @@ final class Guard_Runner {
 	}
 
 	/**
-	 * Check if an IP is within a CIDR range.
+	 * Check whether an IP falls inside a CIDR range.
 	 *
-	 * Ported from Comment & Form Guard's Comment_Form_Guard_Helpers::ip_in_cidr().
+	 * Handles IPv4 and IPv6 through the same path by comparing the packed
+	 * binary forms from inet_pton(): 4 bytes for IPv4, 16 for IPv6. The
+	 * previous implementation used ip2long() and 32-bit arithmetic, so an
+	 * IPv6 range in the allowlist silently never matched.
+	 *
+	 * @param string $ip   Visitor IP.
+	 * @param string $cidr Range in CIDR notation.
+	 * @return bool
 	 */
 	private static function ip_in_cidr( string $ip, string $cidr ): bool {
 		if ( ! str_contains( $cidr, '/' ) ) {
 			return false;
 		}
 
-		[ $subnet, $mask ] = explode( '/', $cidr );
+		[ $subnet, $prefix ] = explode( '/', $cidr, 2 );
 
-		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 )
-			&& filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-			$ip_long     = ip2long( $ip );
-			$subnet_long = ip2long( $subnet );
-			$mask_long   = -1 << ( 32 - (int) $mask );
-
-			return ( $ip_long & $mask_long ) === ( $subnet_long & $mask_long );
+		if ( '' === $prefix || ! ctype_digit( $prefix ) ) {
+			return false;
 		}
 
-		return false;
+		$ip_packed     = @inet_pton( $ip );     // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- returns false for malformed input, which is handled below.
+		$subnet_packed = @inet_pton( $subnet ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- as above.
+
+		if ( false === $ip_packed || false === $subnet_packed ) {
+			return false;
+		}
+
+		// Different address families never match (4 bytes vs 16).
+		if ( strlen( $ip_packed ) !== strlen( $subnet_packed ) ) {
+			return false;
+		}
+
+		$bits = (int) $prefix;
+		$max  = strlen( $ip_packed ) * 8;
+
+		if ( $bits > $max ) {
+			return false;
+		}
+
+		$whole_bytes   = intdiv( $bits, 8 );
+		$leftover_bits = $bits % 8;
+
+		if ( $whole_bytes > 0 && strncmp( $ip_packed, $subnet_packed, $whole_bytes ) !== 0 ) {
+			return false;
+		}
+
+		if ( 0 === $leftover_bits ) {
+			return true;
+		}
+
+		// Compare only the significant high bits of the next byte.
+		$mask = chr( ( 0xFF << ( 8 - $leftover_bits ) ) & 0xFF );
+
+		return ( $ip_packed[ $whole_bytes ] & $mask ) === ( $subnet_packed[ $whole_bytes ] & $mask );
 	}
 }

--- a/includes/guards/class-honeypot.php
+++ b/includes/guards/class-honeypot.php
@@ -11,24 +11,25 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Honeypot extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
-		$field_name = $this->config['field_name'] ?? 'simple_spam_shield_website_url';
+	/**
+	 * The hidden field's name.
+	 *
+	 * Intentionally a constant rather than configuration: the name is also
+	 * hardcoded in the rendered markup, the front-end script and every
+	 * integration that forwards it, so a configurable value that only this
+	 * class honoured would silently disable the guard. See #23 for wiring it
+	 * through properly, which would allow a per-site randomised name.
+	 */
+	public const FIELD = 'simple_spam_shield_website_url';
 
+	public function check( array $data, string $context ): \WP_Error|true {
 		// If the honeypot field is present and non-empty, it's a bot.
-		if ( ! empty( $data[ $field_name ] ) ) {
+		if ( ! empty( $data[ self::FIELD ] ) ) {
 			return $this->fail(
 				__( 'Submission rejected.', 'onsite-spam-guard' )
 			);
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get the honeypot field name for use in form rendering.
-	 */
-	public static function get_field_name(): string {
-		$config = \Simple_Spam_Shield\Core\Config::get( 'guards', 'guards', [] );
-		return $config['honeypot']['field_name'] ?? 'simple_spam_shield_website_url';
 	}
 }

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Onsite Spam Guard 1.2.0\n"
+"Project-Id-Version: Onsite Spam Guard 1.2.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/onsite-spam-guard\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-21T19:50:32+00:00\n"
+"POT-Creation-Date: 2026-08-21T21:25:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -58,39 +58,39 @@ msgid "User Agent"
 msgstr ""
 
 #: admin/class-spam-logs-list-table.php:69
-#: admin/class-spam-logs-list-table.php:105
+#: admin/class-spam-logs-list-table.php:109
 msgid "Delete"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:171
+#: admin/class-spam-logs-list-table.php:180
 msgid "Filter by guard"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:173
+#: admin/class-spam-logs-list-table.php:182
 msgid "All guards"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:184
+#: admin/class-spam-logs-list-table.php:193
 msgid "Filter by context"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:186
+#: admin/class-spam-logs-list-table.php:195
 msgid "All contexts"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:197
+#: admin/class-spam-logs-list-table.php:206
 msgid "Filter"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:206
+#: admin/class-spam-logs-list-table.php:215
 msgid "No blocked submissions recorded yet."
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:262
+#: admin/class-spam-logs-list-table.php:271
 msgid "You do not have permission to delete these entries."
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:267
+#: admin/class-spam-logs-list-table.php:276
 msgid "Nonce verification failed."
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 msgid "Duplicate submission detected — please wait before resubmitting."
 msgstr ""
 
-#: includes/guards/class-honeypot.php:20
+#: includes/guards/class-honeypot.php:29
 msgid "Submission rejected."
 msgstr ""
 

--- a/onsite-spam-guard.php
+++ b/onsite-spam-guard.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Onsite Spam Guard
  * Description: Config-driven spam prevention for Comments, WooCommerce Reviews, and Jetpack Contact Form blocks — no external services required.
- * Version:     1.2.0
+ * Version:     1.2.1
  * Requires at least: 6.2
  * Requires PHP: 8.2
  * Author:      Jerome Wincek
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.2.0' );
+define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.2.1' );
 define( 'SIMPLE_SPAM_SHIELD_FILE', __FILE__ );
 define( 'SIMPLE_SPAM_SHIELD_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLE_SPAM_SHIELD_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: spam, antispam, comments, honeypot, woocommerce
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -100,6 +100,11 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 
 == Changelog ==
 
+= 1.2.1 =
+* Fixed: allowlist entries using an IPv6 range (for example 2001:db8::/32) never matched. IPv4 ranges, exact addresses and email rules were unaffected.
+* Fixed: rate-limit data left rows behind in the database when the plugin was deleted.
+* Fixed: the honeypot guard's field name is no longer presented as configurable, since changing it disabled the guard rather than renaming the field.
+
 = 1.2.0 =
 * New Rate limit guard: throttles repeated submissions from the same sender (the logged-in user where there is one, otherwise the connection IP). Off by default.
 * New option to also apply WordPress's Disallowed Comment Keys (Settings → Discussion) to every protected form, extending that one blocklist beyond comments to reviews, Jetpack forms, and forms added through the plugin's API.
@@ -136,6 +141,9 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 * Developed by Jerome Wincek, with engineering assistance from Anthropic's Claude.
 
 == Upgrade Notice ==
+
+= 1.2.1 =
+Fixes IPv6 allowlist entries being ignored, plus two smaller issues. Recommended if you allowlist by IP range.
 
 = 1.2.0 =
 Adds an optional rate-limit guard and an option to reuse WordPress's own Disallowed Comment Keys on every protected form. Both are off by default; nothing changes unless you enable them.

--- a/tests/AllowlistTest.php
+++ b/tests/AllowlistTest.php
@@ -1,0 +1,105 @@
+<?php
+declare( strict_types=1 );
+
+use PHPUnit\Framework\TestCase;
+use Simple_Spam_Shield\Core\Config;
+use Simple_Spam_Shield\Core\Guard_Runner;
+
+/**
+ * The allowlist is the documented escape hatch for false positives, so a
+ * silent failure there is especially unhelpful — an admin believes a visitor
+ * is exempt and they are not.
+ *
+ * is_allowlisted() and ip_in_cidr() are private, so these exercise them the
+ * way the plugin does: through Guard_Runner::run() with a submission that
+ * would otherwise be blocked. A filled honeypot is the highest-weight guard,
+ * so "passes anyway" can only mean the allowlist bypassed the pipeline.
+ */
+final class AllowlistTest extends TestCase {
+
+	public static function setUpBeforeClass(): void {
+		Config::init( SIMPLE_SPAM_SHIELD_PLUGIN_ROOT . '/config/' );
+		Guard_Runner::init();
+	}
+
+	protected function setUp(): void {
+		$GLOBALS['simple_spam_shield_test_options']    = [
+			'simple_spam_shield_enabled'     => true,
+			'simple_spam_shield_log_blocked' => false,
+		];
+		$GLOBALS['simple_spam_shield_test_transients'] = [];
+		$_POST                                         = [];
+	}
+
+	/** A submission that every install would block: the honeypot is filled. */
+	private function spammy(): array {
+		return [
+			'content'                        => 'buy cheap things',
+			'author'                         => 'Bot',
+			'email'                          => 'bot@example.com',
+			'simple_spam_shield_website_url' => 'http://spam.example',
+		];
+	}
+
+	private function allow( string $list, string $ip ): bool {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_allowlist'] = $list;
+		$_SERVER['REMOTE_ADDR'] = $ip;
+		return true === Guard_Runner::run( $this->spammy(), 'comment' );
+	}
+
+	public function test_blocked_when_the_allowlist_is_empty(): void {
+		$this->assertFalse( $this->allow( '', '192.0.2.10' ) );
+	}
+
+	public function test_exact_ipv4_match_bypasses_every_guard(): void {
+		$this->assertTrue( $this->allow( '192.0.2.10', '192.0.2.10' ) );
+	}
+
+	public function test_non_matching_exact_ip_does_not_bypass(): void {
+		$this->assertFalse( $this->allow( '192.0.2.11', '192.0.2.10' ) );
+	}
+
+	public function test_ipv4_cidr_range(): void {
+		$this->assertTrue( $this->allow( '192.0.2.0/24', '192.0.2.10' ) );
+		$this->assertFalse( $this->allow( '198.51.100.0/24', '192.0.2.10' ) );
+	}
+
+	/** Regression: IPv6 ranges silently never matched before this was fixed. */
+	public function test_ipv6_cidr_range(): void {
+		$this->assertTrue( $this->allow( '2001:db8::/32', '2001:db8::1' ) );
+		$this->assertFalse( $this->allow( '2001:db8::/32', '2001:db9::1' ) );
+	}
+
+	public function test_exact_ipv6_address(): void {
+		$this->assertTrue( $this->allow( '2001:db8::1', '2001:db8::1' ) );
+	}
+
+	public function test_address_families_do_not_cross_match(): void {
+		$this->assertFalse( $this->allow( '2001:db8::/32', '192.0.2.10' ) );
+		$this->assertFalse( $this->allow( '192.0.2.0/24', '2001:db8::1' ) );
+	}
+
+	public function test_malformed_entries_are_ignored_rather_than_matching_everything(): void {
+		foreach ( [ 'not-an-ip/24', '192.0.2.0/abc', '192.0.2.0/33', '///' ] as $bad ) {
+			$this->assertFalse( $this->allow( $bad, '192.0.2.10' ), "entry: {$bad}" );
+		}
+	}
+
+	public function test_exact_email_match(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_allowlist'] = 'bot@example.com';
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.10';
+		$this->assertTrue( true === Guard_Runner::run( $this->spammy(), 'comment' ) );
+	}
+
+	public function test_email_domain_pattern(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_allowlist'] = '@example.com';
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.10';
+		$this->assertTrue( true === Guard_Runner::run( $this->spammy(), 'comment' ) );
+	}
+
+	public function test_multiple_entries_one_line_each(): void {
+		$list = "198.51.100.5\n2001:db8::/32\n@trusted.invalid";
+		$this->assertTrue( $this->allow( $list, '2001:db8::99' ) );
+		$this->assertFalse( $this->allow( $list, '203.0.113.1' ) );
+	}
+}

--- a/tests/HoneypotTest.php
+++ b/tests/HoneypotTest.php
@@ -25,10 +25,22 @@ final class HoneypotTest extends TestCase {
 		$this->assertTrue( $this->guard()->check( [], 'comment' ) );
 	}
 
-	public function test_respects_a_custom_field_name_from_config(): void {
+	/**
+	 * The field name is a constant, not configuration. It used to be readable
+	 * from guards.json while the markup, front-end script and integrations all
+	 * hardcoded it, so a changed value disabled the guard instead of renaming
+	 * the field. Constructor config must not be able to override it.
+	 */
+	public function test_field_name_is_not_overridable_by_config(): void {
 		$guard = new Honeypot( 'honeypot', [ 'field_name' => 'my_trap' ] );
-		$this->assertInstanceOf( WP_Error::class, $guard->check( [ 'my_trap' => 'x' ], 'comment' ) );
-		// The default field name no longer applies.
-		$this->assertTrue( $guard->check( [ 'simple_spam_shield_website_url' => 'x' ], 'comment' ) );
+
+		// The real field still blocks...
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$guard->check( [ Honeypot::FIELD => 'http://spam.example' ], 'comment' )
+		);
+
+		// ...and a name supplied via config is ignored rather than honoured.
+		$this->assertTrue( $guard->check( [ 'my_trap' => 'http://spam.example' ], 'comment' ) );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -64,10 +64,17 @@ function simple_spam_shield_uninstall_site(): void {
 		delete_option( $option );
 	}
 
-	// 3. Clean up any duplicate-detection transients. They use the pattern
-	// simple_spam_shield_dup_* but cannot be enumerated without a query.
+	// 3. Clean up every transient the plugin creates. Matching on the shared
+	// prefix covers duplicate detection, rate limiting, and anything added
+	// later, rather than naming each family and forgetting one — the
+	// rate-limit transients added in 1.2.0 were missed by the old pattern.
+	//
+	// Underscores are escaped: `_` is a single-character wildcard in SQL LIKE,
+	// so an unescaped pattern matches more loosely than it appears to.
 	$wpdb->query(
-		"DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_simple_spam_shield_dup_%' OR option_name LIKE '_transient_timeout_simple_spam_shield_dup_%'"
+		"DELETE FROM {$wpdb->options}
+		  WHERE option_name LIKE '\\_transient\\_simple\\_spam\\_shield\\_%'
+		     OR option_name LIKE '\\_transient\\_timeout\\_simple\\_spam\\_shield\\_%'"
 	); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
 	// 4. Delete the stats transient.


### PR DESCRIPTION
Closes #16. Closes #17. Closes #18.

Three self-contained bug fixes, no behaviour changes beyond the fixes themselves. All three were found by auditing the codebase after 1.2.0 shipped rather than reported.

**#17 is the one that matters most.** An IPv6 range in the allowlist never matched — silently, in the control that exists specifically to rescue people from false positives. The allowlist also turned out to have **no test coverage at all**; it now has 11 cases, verified to fail against the old implementation and pass against the fix.

**#16** left rate-limit transients in `wp_options` after deletion. Also fixes unescaped `_` wildcards in the `LIKE` patterns, which made them looser than they read.

**#18** removes a configurable honeypot field name that only the guard honoured — changing it disabled the highest-weight guard rather than renaming the field. Doing it properly, with a per-site randomised name, is filed as #23.

Local gate: PHPStan clean, **89 tests** (up from 78), PHPCS clean, version metadata consistent, `.pot` up to date, Plugin Check clean on the built package.