### PR TITLE
Record every guard that matched, not just the first (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The user-facing changelog shipped to WordPress.org lives in the
 
 ## [Unreleased]
 
+### Added
+- The spam log now records **every** guard that matched a blocked submission,
+  not just the first one to fire. The guard that decided the outcome is still
+  shown on its own line in the log viewer, with any additional matches listed
+  beneath it, so the guard filter and the 7-day summary are unchanged.
+- `Guard_Interface::check()` takes a third `$observe_only` argument. The runner
+  keeps its short-circuit for the *verdict* — the highest-weight failure still
+  decides the outcome and the message the visitor sees — but continues
+  evaluating the remaining guards for the record. Guards called that way must
+  not change state.
+
+### Changed
+- `Duplicate` and `Rate_Limit` skip their transient writes while observing. This
+  matters in both directions: a blocked submission no longer registers itself in
+  the duplicate cache (which would have rejected a visitor who fixed the problem
+  and resubmitted the same content), and no longer consumes rate-limit budget it
+  did not get through on.
+- Database schema 1.1 -> 1.2 adds a `guards_matched` column, applied by
+  `dbDelta` on upgrade. Existing rows are preserved and simply carry an empty
+  value.
+
 ## [1.2.1] - 2026-08-21
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,20 @@ so guards never need to know about comment arrays vs. Jetpack field data.
    namespace Simple_Spam_Shield\Guards;
 
    final class My_Guard extends Abstract_Guard {
-       public function check( array $data, string $context ): \WP_Error|true {
+       public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
            // Return true to pass, or $this->fail( $message ) to block.
        }
    }
    ```
+
+   **`$observe_only` matters if your guard changes state.** The runner keeps
+   evaluating after a submission has already been blocked, so the log can record
+   every guard that matched rather than only the first. Guards called that way
+   must return their verdict *without* writing anything — no transients, no
+   options, no queries that mutate. `Duplicate` and `Rate_Limit` are the worked
+   examples: both put their write on the pass path behind
+   `if ( ! $observe_only )`. The verdict must be identical either way. A guard
+   with no side effects can ignore the flag.
 
    The file/class naming follows the autoloader: `My_Guard` →
    `class-my-guard.php`.

--- a/admin/class-spam-logs-list-table.php
+++ b/admin/class-spam-logs-list-table.php
@@ -127,9 +127,39 @@ final class Spam_Logs_List_Table extends \WP_List_Table {
 					get_option( 'date_format' ) . ' ' . get_option( 'time_format' )
 				)
 			),
-			'guard', 'context', 'reason', 'ip_address' => esc_html( $item->$column_name ),
+			'context', 'reason', 'ip_address' => esc_html( $item->$column_name ),
 			default => '',
 		};
+	}
+
+	/**
+	 * Guard column — the guard that decided the block, plus any others that
+	 * also matched.
+	 *
+	 * The deciding guard stays on its own line so the column still reads as a
+	 * single value and the guard filter (which matches on it) stays coherent.
+	 * Additional matches appear beneath rather than in a tooltip, so they are
+	 * readable without a mouse.
+	 *
+	 * @param \stdClass $item Log row.
+	 */
+	public function column_guard( $item ): string {
+		$deciding = esc_html( (string) $item->guard );
+
+		$matched = array_filter( array_map( 'trim', explode( ',', (string) ( $item->guards_matched ?? '' ) ) ) );
+		$others  = array_values( array_diff( $matched, [ (string) $item->guard ] ) );
+
+		if ( ! $others ) {
+			return $deciding;
+		}
+
+		return sprintf(
+			'%1$s<br><span class="description">%2$s %3$s</span>',
+			$deciding,
+			/* translators: prefix for the additional guards that also matched a blocked submission. */
+			esc_html__( 'also:', 'onsite-spam-guard' ),
+			esc_html( implode( ', ', $others ) )
+		);
 	}
 
 	/**

--- a/includes/core/class-database-manager.php
+++ b/includes/core/class-database-manager.php
@@ -15,7 +15,7 @@ namespace Simple_Spam_Shield\Core;
 
 final class Database_Manager {
 
-	private const DB_VERSION     = '1.1';
+	private const DB_VERSION     = '1.2';
 	private const DB_VERSION_KEY = 'simple_spam_shield_db_version';
 	private const STATS_KEY      = 'simple_spam_shield_stats';
 
@@ -46,6 +46,7 @@ final class Database_Manager {
 			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 			blocked_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
 			guard varchar(50) NOT NULL,
+			guards_matched varchar(255) NOT NULL DEFAULT '',
 			context varchar(50) NOT NULL,
 			reason text NOT NULL,
 			content longtext NOT NULL,
@@ -73,16 +74,17 @@ final class Database_Manager {
 		global $wpdb;
 
 		$data = [
-			'blocked_at' => current_time( 'mysql', true ),
-			'guard'      => sanitize_text_field( $entry['guard'] ?? '' ),
-			'context'    => sanitize_text_field( $entry['context'] ?? '' ),
-			'reason'     => sanitize_textarea_field( $entry['reason'] ?? '' ),
-			'content'    => wp_kses_post( mb_substr( $entry['content'] ?? '', 0, 500 ) ),
-			'ip_address' => sanitize_text_field( $entry['ip_address'] ?? '' ),
-			'user_agent' => sanitize_text_field( mb_substr( $entry['user_agent'] ?? '', 0, 255 ) ),
+			'blocked_at'     => current_time( 'mysql', true ),
+			'guard'          => sanitize_text_field( $entry['guard'] ?? '' ),
+			'guards_matched' => sanitize_text_field( $entry['guards_matched'] ?? '' ),
+			'context'        => sanitize_text_field( $entry['context'] ?? '' ),
+			'reason'         => sanitize_textarea_field( $entry['reason'] ?? '' ),
+			'content'        => wp_kses_post( mb_substr( $entry['content'] ?? '', 0, 500 ) ),
+			'ip_address'     => sanitize_text_field( $entry['ip_address'] ?? '' ),
+			'user_agent'     => sanitize_text_field( mb_substr( $entry['user_agent'] ?? '', 0, 255 ) ),
 		];
 
-		$inserted = $wpdb->insert( self::table_name(), $data, [ '%s', '%s', '%s', '%s', '%s', '%s', '%s' ] );
+		$inserted = $wpdb->insert( self::table_name(), $data, [ '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ] );
 
 		return $inserted ? (int) $wpdb->insert_id : false;
 	}

--- a/includes/core/class-guard-runner.php
+++ b/includes/core/class-guard-runner.php
@@ -73,31 +73,55 @@ final class Guard_Runner {
 			return true;
 		}
 
+		$verdict = null;
+		$matched = [];
+
 		foreach ( self::$guards as $guard ) {
 			if ( ! $guard->is_enabled() ) {
 				continue;
 			}
 
-			$result = $guard->check( $data, $context );
+			// Once a guard has blocked, the remaining ones are evaluated for
+			// the record only: their verdict is collected but they must not
+			// change any state. The submission's fate was decided by the first
+			// failure, so nothing here can alter what the visitor sees.
+			$observe_only = null !== $verdict;
 
-			if ( is_wp_error( $result ) ) {
-				self::log_block( $guard->get_slug(), $context, $result->get_error_message(), $data );
-				return $result;
+			$result = $guard->check( $data, $context, $observe_only );
+
+			if ( ! is_wp_error( $result ) ) {
+				continue;
+			}
+
+			$matched[] = $guard->get_slug();
+
+			// The highest-weight failure decides the outcome and the message.
+			if ( null === $verdict ) {
+				$verdict = $result;
 			}
 		}
 
-		return true;
+		if ( null === $verdict ) {
+			return true;
+		}
+
+		self::log_block( $matched[0], $context, $verdict->get_error_message(), $data, $matched );
+
+		return $verdict;
 	}
 
 	/**
 	 * Log a blocked submission to the custom database table.
 	 *
-	 * @param string $guard   Slug of the guard that blocked the submission.
-	 * @param string $context Form context.
-	 * @param string $reason  Human-readable block reason.
-	 * @param array  $data    Normalized submission data (provides the content).
+	 * @param string   $guard   Slug of the guard that blocked the submission.
+	 * @param string   $context Form context.
+	 * @param string   $reason  Human-readable block reason.
+	 * @param array    $data    Normalized submission data (provides the content).
+	 * @param string[] $matched Every guard that failed, in weight order. The
+	 *                          first is $guard; the rest were evaluated for the
+	 *                          record after the outcome was already decided.
 	 */
-	private static function log_block( string $guard, string $context, string $reason, array $data ): void {
+	private static function log_block( string $guard, string $context, string $reason, array $data, array $matched = [] ): void {
 		if ( ! (bool) get_option( 'simple_spam_shield_log_blocked', true ) ) {
 			return;
 		}
@@ -107,12 +131,13 @@ final class Guard_Runner {
 		// form via simple_spam_shield_check()). It is escaped on insert and
 		// only ever rendered escaped in the log table.
 		Database_Manager::insert( [
-			'guard'      => $guard,
-			'context'    => $context,
-			'reason'     => $reason,
-			'content'    => (string) ( $data['content'] ?? '' ),
-			'ip_address' => Request::ip(),
-			'user_agent' => sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ),
+			'guard'          => $guard,
+			'guards_matched' => implode( ',', $matched ),
+			'context'        => $context,
+			'reason'         => $reason,
+			'content'        => (string) ( $data['content'] ?? '' ),
+			'ip_address'     => Request::ip(),
+			'user_agent'     => sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ),
 		] );
 	}
 

--- a/includes/guards/class-behavioral.php
+++ b/includes/guards/class-behavioral.php
@@ -16,7 +16,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Behavioral extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$json = $data['simple_spam_shield_behavioral_data'] ?? '';
 
 		// If the behavioral data field is missing (e.g. Jetpack strips it),

--- a/includes/guards/class-duplicate.php
+++ b/includes/guards/class-duplicate.php
@@ -15,7 +15,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Duplicate extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$content = $data['content'] ?? $data['comment'] ?? '';
 		$author  = $data['author'] ?? $data['author_name'] ?? '';
 		$email   = $data['email'] ?? $data['author_email'] ?? '';
@@ -32,8 +32,14 @@ final class Duplicate extends Abstract_Guard {
 			);
 		}
 
-		// Mark this submission as seen for the duration of the window.
-		set_transient( $transient_key, time(), $window );
+		// Mark this submission as seen for the duration of the window. Skipped
+		// when only observing, so a submission already blocked by an earlier
+		// guard does not register itself — otherwise a visitor who fixed
+		// whatever tripped them and resubmitted the same content would be
+		// rejected as a duplicate of their own blocked attempt.
+		if ( ! $observe_only ) {
+			set_transient( $transient_key, time(), $window );
+		}
 
 		return true;
 	}

--- a/includes/guards/class-guard-interface.php
+++ b/includes/guards/class-guard-interface.php
@@ -14,11 +14,23 @@ interface Guard_Interface {
 	/**
 	 * Run the spam check.
 	 *
-	 * @param array  $data    Submission data.
-	 * @param string $context 'comment' | 'woo_review' | 'jetpack_form'.
+	 * When $observe_only is true the guard MUST return its verdict without
+	 * changing any state: no transients, no options, no database writes. The
+	 * runner uses this to keep evaluating after a submission has already been
+	 * blocked, so the log can record every guard that matched rather than only
+	 * the first — without a blocked submission consuming rate-limit budget or
+	 * registering itself in the duplicate cache.
+	 *
+	 * The verdict must be identical in both modes. Guards with no side effects
+	 * can ignore the flag entirely.
+	 *
+	 * @param array  $data         Submission data.
+	 * @param string $context      'comment' | 'woo_review' | 'jetpack_form', or a
+	 *                             custom label from simple_spam_shield_check().
+	 * @param bool   $observe_only Evaluate without mutating state.
 	 * @return \WP_Error|true  True on pass, WP_Error on fail.
 	 */
-	public function check( array $data, string $context ): \WP_Error|true;
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true;
 
 	/**
 	 * Whether this guard is enabled in settings.

--- a/includes/guards/class-honeypot.php
+++ b/includes/guards/class-honeypot.php
@@ -22,7 +22,7 @@ final class Honeypot extends Abstract_Guard {
 	 */
 	public const FIELD = 'simple_spam_shield_website_url';
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		// If the honeypot field is present and non-empty, it's a bot.
 		if ( ! empty( $data[ self::FIELD ] ) ) {
 			return $this->fail(

--- a/includes/guards/class-keyword-block.php
+++ b/includes/guards/class-keyword-block.php
@@ -18,7 +18,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Keyword_Block extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$content = $data['content'] ?? $data['comment'] ?? '';
 		$author  = $data['author'] ?? $data['author_name'] ?? '';
 		$email   = $data['email'] ?? $data['author_email'] ?? '';

--- a/includes/guards/class-link-limit.php
+++ b/includes/guards/class-link-limit.php
@@ -11,7 +11,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Link_Limit extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$max_links = (int) get_option( 'simple_spam_shield_link_limit_max', $this->config['max_links'] ?? 3 );
 		$content   = $data['content'] ?? $data['comment'] ?? '';
 

--- a/includes/guards/class-nonce.php
+++ b/includes/guards/class-nonce.php
@@ -23,7 +23,7 @@ final class Nonce extends Abstract_Guard {
 
 	public const FIELD = 'simple_spam_shield_form_loaded';
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$token = (string) ( $data[ self::FIELD ] ?? '' );
 
 		if ( '' === $token ) {

--- a/includes/guards/class-rate-limit.php
+++ b/includes/guards/class-rate-limit.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class Rate_Limit extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$max = (int) get_option( 'simple_spam_shield_rate_limit_max', $this->config['max_per_window'] ?? 10 );
 
 		// A max of 0 (or less) disables the limit.
@@ -45,7 +45,11 @@ final class Rate_Limit extends Abstract_Guard {
 
 		// Rolling window: each accepted submission extends the window, so a
 		// persistent sender stays throttled until they pause for $window.
-		set_transient( $key, $count + 1, $window );
+		// Skipped when only observing: the count should reflect submissions
+		// that got through, not ones an earlier guard already rejected.
+		if ( ! $observe_only ) {
+			set_transient( $key, $count + 1, $window );
+		}
 
 		return true;
 	}

--- a/includes/guards/class-time-gate.php
+++ b/includes/guards/class-time-gate.php
@@ -11,7 +11,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Time_Gate extends Abstract_Guard {
 
-	public function check( array $data, string $context ): \WP_Error|true {
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
 		$min_seconds = (int) get_option( 'simple_spam_shield_time_gate_seconds', $this->config['min_seconds'] ?? 3 );
 
 		$token = (string) ( $data['simple_spam_shield_form_loaded'] ?? '' );

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-21T21:25:30+00:00\n"
+"POT-Creation-Date: 2026-08-21T22:02:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -62,35 +62,40 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:180
+#. translators: prefix for the additional guards that also matched a blocked submission.
+#: admin/class-spam-logs-list-table.php:160
+msgid "also:"
+msgstr ""
+
+#: admin/class-spam-logs-list-table.php:210
 msgid "Filter by guard"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:182
+#: admin/class-spam-logs-list-table.php:212
 msgid "All guards"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:193
+#: admin/class-spam-logs-list-table.php:223
 msgid "Filter by context"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:195
+#: admin/class-spam-logs-list-table.php:225
 msgid "All contexts"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:206
+#: admin/class-spam-logs-list-table.php:236
 msgid "Filter"
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:215
+#: admin/class-spam-logs-list-table.php:245
 msgid "No blocked submissions recorded yet."
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:271
+#: admin/class-spam-logs-list-table.php:301
 msgid "You do not have permission to delete these entries."
 msgstr ""
 
-#: admin/class-spam-logs-list-table.php:276
+#: admin/class-spam-logs-list-table.php:306
 msgid "Nonce verification failed."
 msgstr ""
 

--- a/tests/EvaluateAllGuardsTest.php
+++ b/tests/EvaluateAllGuardsTest.php
@@ -1,0 +1,139 @@
+<?php
+declare( strict_types=1 );
+
+use PHPUnit\Framework\TestCase;
+use Simple_Spam_Shield\Core\Config;
+use Simple_Spam_Shield\Core\Guard_Runner;
+use Simple_Spam_Shield\Guards\Duplicate;
+use Simple_Spam_Shield\Guards\Rate_Limit;
+
+/**
+ * The runner keeps its short-circuit for the *verdict* but keeps evaluating
+ * for the *record*, so the log can show every guard that matched.
+ *
+ * The contract that makes this safe: guards evaluated after the outcome is
+ * decided run in observe-only mode and must not change state.
+ */
+final class EvaluateAllGuardsTest extends TestCase {
+
+	private const SECRET = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+	public static function setUpBeforeClass(): void {
+		Config::init( SIMPLE_SPAM_SHIELD_PLUGIN_ROOT . '/config/' );
+		Guard_Runner::init();
+	}
+
+	protected function setUp(): void {
+		$GLOBALS['simple_spam_shield_test_options']    = [
+			'simple_spam_shield_enabled'           => true,
+			'simple_spam_shield_log_blocked'       => false,
+			'simple_spam_shield_token_secret'      => self::SECRET,
+			'simple_spam_shield_blocked_keywords'  => 'casino',
+			'simple_spam_shield_link_limit_max'    => 2,
+		];
+		$GLOBALS['simple_spam_shield_test_transients'] = [];
+		$GLOBALS['simple_spam_shield_test_user_id']    = 0;
+		$_SERVER['REMOTE_ADDR']                        = '198.51.100.5';
+		$_POST                                         = [];
+	}
+
+	private function token(): string {
+		$issued = time() - 30;
+		return $issued . '.' . hash_hmac( 'sha256', (string) $issued, self::SECRET );
+	}
+
+	// --- the guards themselves -------------------------------------------
+
+	public function test_duplicate_does_not_record_the_submission_when_observing(): void {
+		$guard = new Duplicate( 'duplicate', [ 'window_seconds' => 60 ] );
+		$data  = [ 'content' => 'hello', 'author' => 'A', 'email' => 'a@example.com' ];
+
+		$this->assertTrue( $guard->check( $data, 'comment', true ) );
+		// Observing must leave no trace, so the same content still passes.
+		$this->assertTrue( $guard->check( $data, 'comment', true ) );
+
+		// A real (non-observing) pass does record it.
+		$this->assertTrue( $guard->check( $data, 'comment' ) );
+		$this->assertInstanceOf( WP_Error::class, $guard->check( $data, 'comment' ) );
+	}
+
+	public function test_rate_limit_does_not_consume_budget_when_observing(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max'] = 2;
+		$guard = new Rate_Limit( 'rate_limit', [ 'max_per_window' => 2, 'window_seconds' => 60 ] );
+
+		for ( $i = 0; $i < 10; $i++ ) {
+			$this->assertTrue( $guard->check( [], 'comment', true ), "observation {$i} consumed budget" );
+		}
+
+		// Budget is untouched, so two real submissions still pass.
+		$this->assertTrue( $guard->check( [], 'comment' ) );
+		$this->assertTrue( $guard->check( [], 'comment' ) );
+		$this->assertInstanceOf( WP_Error::class, $guard->check( [], 'comment' ) );
+	}
+
+	public function test_verdict_is_identical_in_both_modes(): void {
+		$guard = new Rate_Limit( 'rate_limit', [ 'max_per_window' => 1, 'window_seconds' => 60 ] );
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max'] = 1;
+
+		$guard->check( [], 'comment' );                    // consume the single slot
+		$observed = $guard->check( [], 'comment', true );
+		$real     = $guard->check( [], 'comment' );
+
+		$this->assertInstanceOf( WP_Error::class, $observed );
+		$this->assertInstanceOf( WP_Error::class, $real );
+		$this->assertSame( $real->get_error_code(), $observed->get_error_code() );
+	}
+
+	// --- the runner -------------------------------------------------------
+
+	/** A submission tripping several guards is still decided by the first. */
+	public function test_highest_weight_guard_still_decides_the_outcome(): void {
+		$data = [
+			'content'                        => 'visit my casino http://a.example http://b.example http://c.example',
+			'simple_spam_shield_website_url' => 'http://bot.example',   // honeypot, weight 100
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+
+		$result = Guard_Runner::run( $data, 'comment' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'simple_spam_shield_honeypot_failed', $result->get_error_code() );
+	}
+
+	/** A clean submission is unaffected by the change. */
+	public function test_clean_submission_still_passes(): void {
+		$data = [
+			'content'                        => 'a perfectly ordinary comment',
+			'simple_spam_shield_website_url' => '',
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+
+		$this->assertTrue( Guard_Runner::run( $data, 'comment' ) );
+	}
+
+	/**
+	 * A blocked submission must not consume rate-limit budget on its way out.
+	 * Before observe-only this was impossible to get wrong, because the
+	 * rate-limit guard never ran once an earlier guard had blocked.
+	 */
+	public function test_blocked_submission_does_not_consume_rate_limit_budget(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max']     = 2;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_enabled'] = true;
+
+		$blocked = [
+			'content'                        => 'hello',
+			'simple_spam_shield_website_url' => 'http://bot.example',
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->assertInstanceOf( WP_Error::class, Guard_Runner::run( $blocked, 'comment' ) );
+		}
+
+		$clean = [
+			'content'                        => 'an ordinary comment',
+			'simple_spam_shield_website_url' => '',
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+		$this->assertTrue( Guard_Runner::run( $clean, 'comment' ) );
+	}
+}


### PR DESCRIPTION
Closes #13. First half of the **1.3.0** milestone; #6 follows.

The runner keeps its short-circuit for the **verdict** — the highest-weight failure still decides the outcome and the message the visitor sees — but keeps evaluating the rest for the **record**.

### The interface change is the reason this goes first

`Guard_Interface::check()` gains a third `$observe_only` argument. Adding a parameter to an interface method is breaking for implementers, and #6 is about to publish this interface to third-party guards. Today it is free; after #6 it is not. Doing #6 first would mean publishing an interface and immediately breaking it — a stronger argument for the ordering than the one I gave when scheduling the milestone.

### Why it is safe

Both guards with side effects put their write on the *pass* path, so observing is a clean skip and the verdict is identical either way:

- **Duplicate** no longer registers a submission an earlier guard already blocked — otherwise a visitor who fixed the problem and resubmitted the same content would be rejected as a duplicate of their own failed attempt.
- **Rate_Limit** no longer consumes budget for submissions that never got through.

### Verified

- Schema 1.1 → 1.2 tested on a live database: column added, **existing rows preserved**, and a real block recorded `honeypot,link_limit,keyword_block`.
- `EvaluateAllGuardsTest` fails with **3 failures** when the observe-only writes are un-guarded, passes with them. 95 tests total.
- The `.pot` drift check added in the 1.2.0 cycle caught the one new translatable string before it could ship missing — doing the job it was filed for.

Version stays at 1.2.1 with notes under `[Unreleased]`; the bump to 1.3.0 comes with #6.