### PR TITLE
Public extension API for third-party guards (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ The user-facing changelog shipped to WordPress.org lives in the
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-21
+
 ### Added
+- Other plugins can register their own guard through the new
+  `simple_spam_shield_guards` filter. A registered guard participates fully:
+  sorted by weight, short-circuiting on failure, recorded in the log, and given
+  its own on/off toggle on the Guards settings tab, because the pipeline and the
+  settings screen now read the same filtered definitions. The filter can also
+  adjust or remove a built-in guard. A class that does not implement
+  `Guard_Interface`, or a filter that returns something other than an array, is
+  refused and the built-in guards are kept rather than leaving the site
+  unprotected.
+- New `simple_spam_shield_blocked` action, fired once a submission has been
+  blocked and logged, carrying the deciding guard, the context, every guard that
+  matched, and the normalized submission data.
 - The spam log now records **every** guard that matched a blocked submission,
   not just the first one to fire. The guard that decided the outcome is still
   shown on its own line in the log viewer, with any additional matches listed
@@ -22,11 +36,16 @@ The user-facing changelog shipped to WordPress.org lives in the
   not change state.
 
 ### Changed
-- `Duplicate` and `Rate_Limit` skip their transient writes while observing. This
-  matters in both directions: a blocked submission no longer registers itself in
-  the duplicate cache (which would have rejected a visitor who fixed the problem
-  and resubmitted the same content), and no longer consumes rate-limit budget it
-  did not get through on.
+- `Duplicate` and `Rate_Limit` skip their transient writes while observing, so a
+  submission already blocked by a higher-weight guard no longer registers itself
+  in the duplicate cache and no longer consumes rate-limit budget.
+
+  Note the limit of this: a guard only observes once some *earlier* guard has
+  decided the block. `Duplicate` runs at weight 95 with only `Honeypot` above it,
+  so a submission blocked by any of the six lower-weight guards has already been
+  recorded by the time the block happens, and an identical resubmission is then
+  refused as a duplicate. Recording only submissions that clear the whole
+  pipeline needs a separate commit step and is tracked as its own issue.
 - Database schema 1.1 -> 1.2 adds a `guards_matched` column, applied by
   `dbDelta` on upgrade. Existing rows are preserved and simply carry an empty
   value.
@@ -184,7 +203,8 @@ Initial release.
   their own forms: `simple_spam_shield_check()`,
   `simple_spam_shield_protect_selector()`, and `simple_spam_shield_field_markup()`.
 
-[Unreleased]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/jwincek/onsite-spam-guard/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/jwincek/onsite-spam-guard/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jwincek/onsite-spam-guard/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/jwincek/onsite-spam-guard/compare/v1.1.2...v1.1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,15 +134,31 @@ so guards never need to know about comment arrays vs. Jetpack field data.
    `enabled_by_default`, `weight`, and any per-guard thresholds (read in the
    guard via `$this->config[...]`).
 
-3. **Register it** in `Guard_Runner::init()`'s `$guard_map` (slug → class).
+3. **Register it** in `Guard_Runner::definitions()`'s `$builtin_classes`
+   (slug → class).
 
-   The on/off toggle appears on the settings page automatically (the admin
-   screen reads `guards.json`). Add a numeric/text setting in
-   `Admin::register_settings()` only if the guard needs one.
+   The on/off toggle appears on the settings page automatically, because
+   `Admin::register_settings()` and the pipeline both read
+   `Guard_Runner::definitions()`. Add a numeric/text setting in
+   `Admin::register_settings()` only if the guard needs a threshold.
 
 4. **Add tests** in `tests/My_GuardTest.php`, covering both the blocking and
    passing paths plus the Jetpack-context behavior if the guard depends on
    JS-injected fields.
+
+**Guards belonging to another plugin** do not go through steps 2 and 3. They are
+registered from outside with the `simple_spam_shield_guards` filter, which
+carries the class in the definition itself — see "Adding your own guard" in
+`README.md`. Anything the filter returns that is not a `Guard_Interface`
+implementation is refused with `_doing_it_wrong()`, and a filter that returns a
+non-array leaves the built-in guards in place rather than dropping the site's
+protection. Keep `definitions()` the single source of truth for what the
+pipeline runs, so a registered guard is never a second-class citizen.
+
+**Known limitation:** the runner only puts a guard in observe mode once an
+*earlier* guard has decided the block, so `Duplicate` and `Rate_Limit` still
+record submissions rejected by a lower-weight guard. Tracked in issue #26; a new
+state-holding guard inherits the same caveat.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,60 @@ if ( function_exists( 'simple_spam_shield_field_markup' ) ) {
 
 Without step 2, only the content-based guards (keyword, link limit, duplicate) apply.
 
+### Adding your own guard
+
+Register a class implementing `Guard_Interface` through the
+`simple_spam_shield_guards` filter, and it joins the pipeline as a first-class
+guard — sorted by weight, short-circuiting on failure, logged, and given its own
+on/off toggle on the Guards settings tab automatically.
+
+```php
+add_filter( 'simple_spam_shield_guards', function ( array $guards ) {
+    $guards['acme_blocklist'] = [
+        'class'              => \Acme\Blocklist_Guard::class,
+        'label'              => 'Acme blocklist',
+        'weight'             => 65,   // higher runs first
+        'enabled_by_default' => true,
+    ];
+    return $guards;
+} );
+```
+
+Register it when your plugin file loads, so the filter is in place before the
+pipeline is built on `plugins_loaded`.
+
+Your guard must honour the third argument to `check()`:
+
+```php
+public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+    // ... decide ...
+    if ( ! $observe_only ) {
+        // only now may you write transients, options, or rows
+    }
+}
+```
+
+The runner keeps evaluating after a submission has already been blocked so the
+log can record every guard that matched. Guards called that way must return the
+same verdict **without changing any state** — see `Duplicate` and `Rate_Limit`
+for worked examples.
+
+The same filter can adjust or remove a built-in guard by editing or unsetting
+its entry.
+
+### Reacting to a block
+
+```php
+add_action( 'simple_spam_shield_blocked', function ( $guard, $context, $matched, $data ) {
+    // $guard   — the guard that decided the block
+    // $matched — every guard that matched, in weight order ($matched[0] === $guard)
+    // $context — 'comment', 'woo_review', 'jetpack_form', or your own label
+}, 10, 4 );
+```
+
+`$data` carries the submitted content, author name and email, so treat it as
+personal data.
+
 ## Lineage
 
 The plugin's architecture draws from two sources:

--- a/includes/core/class-admin.php
+++ b/includes/core/class-admin.php
@@ -145,7 +145,9 @@ final class Admin {
 			echo '<p>' . esc_html__( 'Enable or disable individual spam checks.', 'onsite-spam-guard' ) . '</p>';
 		}, $guards_page );
 
-		$guard_defs = Config::get( 'guards', 'guards', [] );
+		// The filtered definitions, so a guard registered by another plugin
+		// through simple_spam_shield_guards gets its own toggle here too.
+		$guard_defs = Guard_Runner::definitions();
 		foreach ( $guard_defs as $slug => $def ) {
 			self::add_toggle(
 				"simple_spam_shield_{$slug}_enabled",

--- a/includes/core/class-guard-runner.php
+++ b/includes/core/class-guard-runner.php
@@ -27,9 +27,54 @@ final class Guard_Runner {
 	public static function init(): void {
 		self::$guards = []; // Idempotent: re-initializing replaces, never appends.
 
-		$definitions = Config::get( 'guards', 'guards', [] );
+		foreach ( self::definitions() as $slug => $def ) {
+			$class = $def['class'] ?? null;
 
-		$guard_map = [
+			if ( ! is_string( $class ) || ! class_exists( $class ) ) {
+				continue;
+			}
+
+			// A guard that does not implement the contract would fail at the
+			// first submission; skip it now and say why, rather than fataling
+			// on someone's comment form.
+			if ( ! is_subclass_of( $class, Guard_Interface::class ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: guard slug, 2: class name, 3: interface name. */
+						esc_html__( 'Guard "%1$s" was skipped: %2$s does not implement %3$s.', 'onsite-spam-guard' ),
+						esc_html( (string) $slug ),
+						esc_html( $class ),
+						'Guard_Interface'
+					),
+					'1.3.0'
+				);
+				continue;
+			}
+
+			self::$guards[] = new $class( (string) $slug, $def );
+		}
+
+		// Sort by weight descending (highest priority first).
+		usort( self::$guards, fn( Guard_Interface $a, Guard_Interface $b ) => $b->get_weight() <=> $a->get_weight() );
+	}
+
+	/**
+	 * The guard definitions, after filtering.
+	 *
+	 * Built-in guards come from config/guards.json; each entry is given the
+	 * class that implements it. Other plugins can register their own guard, or
+	 * adjust or remove a built-in one, through the
+	 * `simple_spam_shield_guards` filter.
+	 *
+	 * This is the single source of truth for both the pipeline and the
+	 * settings screen, so a registered guard automatically gets its own on/off
+	 * toggle on the Guards tab without any extra work.
+	 *
+	 * @return array<string, array<string, mixed>> Slug => definition.
+	 */
+	public static function definitions(): array {
+		$builtin_classes = [
 			'honeypot'      => \Simple_Spam_Shield\Guards\Honeypot::class,
 			'time_gate'     => \Simple_Spam_Shield\Guards\Time_Gate::class,
 			'nonce'         => \Simple_Spam_Shield\Guards\Nonce::class,
@@ -40,19 +85,50 @@ final class Guard_Runner {
 			'behavioral'    => \Simple_Spam_Shield\Guards\Behavioral::class,
 		];
 
-		foreach ( $definitions as $slug => $def ) {
-			if ( ! isset( $guard_map[ $slug ] ) ) {
+		$definitions = [];
+
+		foreach ( Config::get( 'guards', 'guards', [] ) as $slug => $def ) {
+			if ( ! isset( $builtin_classes[ $slug ] ) ) {
 				continue;
 			}
 
-			$class    = $guard_map[ $slug ];
-			$instance = new $class( $slug, $def );
-
-			self::$guards[] = $instance;
+			$def['class']         = $builtin_classes[ $slug ];
+			$definitions[ $slug ] = $def;
 		}
 
-		// Sort by weight descending (highest priority first).
-		usort( self::$guards, fn( Guard_Interface $a, Guard_Interface $b ) => $b->get_weight() <=> $a->get_weight() );
+		/**
+		 * Filter the guards that make up the spam-check pipeline.
+		 *
+		 * Each entry is keyed by slug and understands:
+		 *
+		 *   class              Fully-qualified class implementing Guard_Interface.
+		 *   label              Shown on the Guards settings tab.
+		 *   description        Optional longer explanation.
+		 *   weight             Higher runs first; the highest-weight failure
+		 *                      decides the outcome and the visitor's message.
+		 *   enabled_by_default Whether the toggle starts on.
+		 *
+		 * Any other keys are handed to the guard's constructor as its config.
+		 *
+		 * Hook this before `plugins_loaded` priority 10 — registering it when
+		 * your plugin file loads is the usual way.
+		 *
+		 * A registered guard must honour the `$observe_only` argument to
+		 * `check()`: the runner keeps evaluating after a submission has already
+		 * been blocked so the log can record every guard that matched, and
+		 * guards called that way must not change any state.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param array<string, array<string, mixed>> $definitions Slug => definition.
+		 */
+		/** @var mixed $filtered */
+		$filtered = apply_filters( 'simple_spam_shield_guards', $definitions );
+
+		// A filter belonging to another plugin can return anything. Falling back
+		// to an empty list would silently disable every guard and leave the site
+		// unprotected, so fall back to the built-in definitions instead.
+		return is_array( $filtered ) ? $filtered : $definitions;
 	}
 
 	/**
@@ -106,6 +182,30 @@ final class Guard_Runner {
 		}
 
 		self::log_block( $matched[0], $context, $verdict->get_error_message(), $data, $matched );
+
+		/**
+		 * Fires when a submission has been blocked.
+		 *
+		 * Runs after the block is logged and just before the error is returned
+		 * to whichever integration is handling the submission. Use it to
+		 * notify, count, or feed a dashboard without polling the log table.
+		 *
+		 * Thanks to the pipeline evaluating every guard, $matched lists all of
+		 * them, not just the one that decided the outcome — $guard is always
+		 * $matched[0].
+		 *
+		 * $data carries the submitted content, author name and email, so treat
+		 * it as personal data: do not send it anywhere the site owner has not
+		 * agreed to.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param string   $guard   Slug of the guard that decided the block.
+		 * @param string   $context Form context, e.g. 'comment' or a custom label.
+		 * @param string[] $matched Every guard that matched, in weight order.
+		 * @param array    $data    Normalized submission data.
+		 */
+		do_action( 'simple_spam_shield_blocked', $matched[0], $context, $matched, $data );
 
 		return $verdict;
 	}

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Onsite Spam Guard 1.2.1\n"
+"Project-Id-Version: Onsite Spam Guard 1.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/onsite-spam-guard\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-21T22:02:05+00:00\n"
+"POT-Creation-Date: 2026-08-21T22:34:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -129,12 +129,12 @@ msgstr ""
 
 #: includes/core/class-admin.php:110
 #: includes/core/class-admin.php:111
-#: includes/core/class-admin.php:395
+#: includes/core/class-admin.php:397
 msgid "Spam Logs"
 msgstr ""
 
 #: includes/core/class-admin.php:130
-#: includes/core/class-admin.php:283
+#: includes/core/class-admin.php:285
 msgid "General"
 msgstr ""
 
@@ -174,136 +174,142 @@ msgstr ""
 msgid "Enable or disable individual spam checks."
 msgstr ""
 
-#: includes/core/class-admin.php:159
+#: includes/core/class-admin.php:161
 msgid "Minimum seconds before submit"
 msgstr ""
 
-#: includes/core/class-admin.php:159
+#: includes/core/class-admin.php:161
 msgid "seconds"
 msgstr ""
 
-#: includes/core/class-admin.php:160
+#: includes/core/class-admin.php:162
 msgid "Maximum links per submission"
 msgstr ""
 
-#: includes/core/class-admin.php:161
+#: includes/core/class-admin.php:163
 msgid "Rate limit: max submissions per minute"
 msgstr ""
 
-#: includes/core/class-admin.php:161
+#: includes/core/class-admin.php:163
 msgid "per sender (0 = no limit)"
 msgstr ""
 
-#: includes/core/class-admin.php:174
+#: includes/core/class-admin.php:176
 msgid "Behavioral suspicion threshold"
 msgstr ""
 
-#: includes/core/class-admin.php:181
+#: includes/core/class-admin.php:183
 msgid "Score between 0.0 (lenient) and 1.0 (strict). Submissions scoring at or above this threshold are blocked. Default 0.6."
 msgstr ""
 
-#: includes/core/class-admin.php:197
+#: includes/core/class-admin.php:199
 msgid "Blocked keywords"
 msgstr ""
 
-#: includes/core/class-admin.php:204
+#: includes/core/class-admin.php:206
 msgid "One keyword or phrase per line. Case-insensitive."
 msgstr ""
 
-#: includes/core/class-admin.php:211
+#: includes/core/class-admin.php:213
 msgid "Also apply WordPress's Disallowed Comment Keys (Settings → Discussion) to every protected form"
 msgstr ""
 
-#: includes/core/class-admin.php:215
-#: includes/core/class-admin.php:291
+#: includes/core/class-admin.php:217
+#: includes/core/class-admin.php:293
 msgid "Allowlist"
 msgstr ""
 
-#: includes/core/class-admin.php:216
+#: includes/core/class-admin.php:218
 msgid "Submissions from allowlisted IPs or emails bypass all guards."
 msgstr ""
 
-#: includes/core/class-admin.php:227
+#: includes/core/class-admin.php:229
 msgid "Allowed IPs and emails"
 msgstr ""
 
-#: includes/core/class-admin.php:234
+#: includes/core/class-admin.php:236
 msgid "One entry per line. Supports: exact IPs (192.168.1.1), CIDR ranges (10.0.0.0/8), exact emails (user@example.com), or email domains (@trusted.org)."
 msgstr ""
 
-#: includes/core/class-admin.php:251
+#: includes/core/class-admin.php:253
 msgid "Trust proxy headers for IP detection"
 msgstr ""
 
-#: includes/core/class-admin.php:256
+#: includes/core/class-admin.php:258
 msgid "Use the X-Forwarded-For header to determine the visitor IP."
 msgstr ""
 
-#: includes/core/class-admin.php:257
+#: includes/core/class-admin.php:259
 msgid "Enable only if this site is behind a trusted reverse proxy or load balancer (e.g. Cloudflare, Nginx). When off, the direct connection IP is used. Turning this on without a trusted proxy lets visitors spoof their IP and bypass the allowlist."
 msgstr ""
 
-#: includes/core/class-admin.php:266
-#: includes/core/class-admin.php:295
+#: includes/core/class-admin.php:268
+#: includes/core/class-admin.php:297
 msgid "Logging"
 msgstr ""
 
-#: includes/core/class-admin.php:267
+#: includes/core/class-admin.php:269
 msgid "Log blocked submissions to database"
 msgstr ""
 
-#: includes/core/class-admin.php:268
+#: includes/core/class-admin.php:270
 msgid "Delete logs older than"
 msgstr ""
 
-#: includes/core/class-admin.php:268
+#: includes/core/class-admin.php:270
 msgid "days (0 = keep forever)"
 msgstr ""
 
-#: includes/core/class-admin.php:269
+#: includes/core/class-admin.php:271
 msgid "Delete all plugin data (spam logs and settings) when this plugin is deleted"
 msgstr ""
 
-#: includes/core/class-admin.php:287
+#: includes/core/class-admin.php:289
 msgid "Guards"
 msgstr ""
 
 #. translators: 1: number of blocked submissions, 2: link to logs page
-#: includes/core/class-admin.php:322
+#: includes/core/class-admin.php:324
 #, php-format
 msgid "%1$d submissions blocked. %2$s"
 msgstr ""
 
-#: includes/core/class-admin.php:325
+#: includes/core/class-admin.php:327
 msgid "View spam logs →"
 msgstr ""
 
-#: includes/core/class-admin.php:400
+#: includes/core/class-admin.php:402
 msgid "All spam logs cleared."
 msgstr ""
 
-#: includes/core/class-admin.php:410
+#: includes/core/class-admin.php:412
 msgid "Delete all log entries?"
 msgstr ""
 
-#: includes/core/class-admin.php:411
+#: includes/core/class-admin.php:413
 msgid "Clear all logs"
 msgstr ""
 
 #. translators: %d: number of submissions blocked in the last 7 days.
-#: includes/core/class-admin.php:420
+#: includes/core/class-admin.php:422
 #, php-format
 msgid "Blocked in the last 7 days: %d."
 msgstr ""
 
 #. translators: 1: guard name, 2: number of blocks by that guard.
-#: includes/core/class-admin.php:427
+#: includes/core/class-admin.php:429
 #, php-format
 msgid "Most active guard: %1$s (%2$d)."
 msgstr ""
 
 #: includes/core/class-assets.php:85
 msgid "Website"
+msgstr ""
+
+#. translators: 1: guard slug, 2: class name, 3: interface name.
+#: includes/core/class-guard-runner.php:45
+#, php-format
+msgid "Guard \"%1$s\" was skipped: %2$s does not implement %3$s."
 msgstr ""
 
 #: includes/guards/class-behavioral.php:43

--- a/onsite-spam-guard.php
+++ b/onsite-spam-guard.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Onsite Spam Guard
  * Description: Config-driven spam prevention for Comments, WooCommerce Reviews, and Jetpack Contact Form blocks — no external services required.
- * Version:     1.2.1
+ * Version:     1.3.0
  * Requires at least: 6.2
  * Requires PHP: 8.2
  * Author:      Jerome Wincek
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.2.1' );
+define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.3.0' );
 define( 'SIMPLE_SPAM_SHIELD_FILE', __FILE__ );
 define( 'SIMPLE_SPAM_SHIELD_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLE_SPAM_SHIELD_URL', plugin_dir_url( __FILE__ ) );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,8 @@
 	<file>.</file>
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
+	<!-- Build output is a copy of the source; scanning it reports every class twice. -->
+	<exclude-pattern>build/*</exclude-pattern>
 	<!-- Unit tests use stub globals and test-only conventions, not WPCS. -->
 	<exclude-pattern>tests/*</exclude-pattern>
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: spam, antispam, comments, honeypot, woocommerce
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.2.1
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -100,6 +100,11 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 
 == Changelog ==
 
+= 1.3.0 =
+* The spam log now records every guard that matched a blocked submission, not just the first one. The guard that decided the outcome is still shown on its own line, with any additional matches listed beneath it.
+* A submission caught by the honeypot no longer counts against the duplicate and rate-limit guards, so it cannot use up a real visitor's allowance.
+* For developers: other plugins can now register their own guard through the simple_spam_shield_guards filter. A registered guard runs in the pipeline, appears in the log, and gets its own toggle on the Guards tab. A new simple_spam_shield_blocked action fires whenever a submission is blocked. See the readme in the plugin's repository.
+
 = 1.2.1 =
 * Fixed: allowlist entries using an IPv6 range (for example 2001:db8::/32) never matched. IPv4 ranges, exact addresses and email rules were unaffected.
 * Fixed: rate-limit data left rows behind in the database when the plugin was deleted.
@@ -141,6 +146,9 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 * Developed by Jerome Wincek, with engineering assistance from Anthropic's Claude.
 
 == Upgrade Notice ==
+
+= 1.3.0 =
+Adds an upgrade to the database table for the richer spam log. Existing log entries are kept. Nothing needs to be reconfigured.
 
 = 1.2.1 =
 Fixes IPv6 allowlist entries being ignored, plus two smaller issues. Recommended if you allowlist by IP range.

--- a/tests/GuardRegistrationTest.php
+++ b/tests/GuardRegistrationTest.php
@@ -1,0 +1,239 @@
+<?php
+declare( strict_types=1 );
+
+use PHPUnit\Framework\TestCase;
+use Simple_Spam_Shield\Core\Config;
+use Simple_Spam_Shield\Core\Guard_Runner;
+use Simple_Spam_Shield\Guards\Abstract_Guard;
+
+/** A guard supplied by a hypothetical third-party plugin. */
+final class Test_External_Guard extends Abstract_Guard {
+	public static int $observed_calls = 0;
+
+	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+		if ( $observe_only ) {
+			++self::$observed_calls;
+		}
+		if ( str_contains( (string) ( $data['content'] ?? '' ), 'forbidden-by-external' ) ) {
+			return $this->fail( 'Blocked by the external guard.' );
+		}
+		return true;
+	}
+}
+
+/** Does not implement Guard_Interface — must be refused rather than fataling. */
+final class Test_Not_A_Guard {}
+
+final class GuardRegistrationTest extends TestCase {
+
+	private const SECRET = 'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg';
+
+	protected function setUp(): void {
+		Config::init( SIMPLE_SPAM_SHIELD_PLUGIN_ROOT . '/config/' );
+		$GLOBALS['simple_spam_shield_test_options']    = [
+			'simple_spam_shield_enabled'      => true,
+			'simple_spam_shield_log_blocked'  => false,
+			'simple_spam_shield_token_secret' => self::SECRET,
+		];
+		$GLOBALS['simple_spam_shield_test_transients'] = [];
+		$GLOBALS['simple_spam_shield_test_filters']    = [];
+		$GLOBALS['simple_spam_shield_test_actions']    = [];
+		$_SERVER['REMOTE_ADDR']                        = '198.51.100.9';
+		$_POST                                         = [];
+		Test_External_Guard::$observed_calls           = 0;
+	}
+
+	private function token(): string {
+		$issued = time() - 30;
+		return $issued . '.' . hash_hmac( 'sha256', (string) $issued, self::SECRET );
+	}
+
+	private function registerExternalGuard( int $weight = 50 ): void {
+		add_filter(
+			'simple_spam_shield_guards',
+			static function ( array $defs ) use ( $weight ): array {
+				$defs['external'] = [
+					'class'              => Test_External_Guard::class,
+					'label'              => 'External guard',
+					'weight'             => $weight,
+					'enabled_by_default' => true,
+				];
+				return $defs;
+			}
+		);
+		Guard_Runner::init();
+	}
+
+	public function test_builtin_guards_are_registered_without_any_filter(): void {
+		Guard_Runner::init();
+		$defs = Guard_Runner::definitions();
+
+		$this->assertArrayHasKey( 'honeypot', $defs );
+		$this->assertSame( 8, count( $defs ) );
+		// Every built-in carries the class that implements it.
+		foreach ( $defs as $slug => $def ) {
+			$this->assertArrayHasKey( 'class', $def, "guard {$slug} has no class" );
+		}
+	}
+
+	public function test_a_registered_guard_participates_in_the_pipeline(): void {
+		$this->registerExternalGuard();
+
+		$result = Guard_Runner::run(
+			[
+				'content'                        => 'this is forbidden-by-external content',
+				'simple_spam_shield_website_url' => '',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'simple_spam_shield_external_failed', $result->get_error_code() );
+	}
+
+	public function test_registered_guard_respects_its_weight(): void {
+		// Above the honeypot (100), so it decides even when the honeypot also matches.
+		$this->registerExternalGuard( 120 );
+
+		$result = Guard_Runner::run(
+			[
+				'content'                        => 'forbidden-by-external',
+				'simple_spam_shield_website_url' => 'http://bot.example',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertSame( 'simple_spam_shield_external_failed', $result->get_error_code() );
+	}
+
+	public function test_registered_guard_is_evaluated_in_observe_mode_after_a_block(): void {
+		// Below the honeypot, so the honeypot decides and this one only observes.
+		$this->registerExternalGuard( 10 );
+
+		Guard_Runner::run(
+			[
+				'content'                        => 'ordinary text',
+				'simple_spam_shield_website_url' => 'http://bot.example',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertSame( 1, Test_External_Guard::$observed_calls );
+	}
+
+	public function test_a_class_that_does_not_implement_the_contract_is_skipped(): void {
+		add_filter(
+			'simple_spam_shield_guards',
+			static function ( array $defs ): array {
+				$defs['bogus'] = [ 'class' => Test_Not_A_Guard::class, 'weight' => 50 ];
+				$defs['absent'] = [ 'class' => 'No\\Such\\Class', 'weight' => 50 ];
+				return $defs;
+			}
+		);
+		Guard_Runner::init();
+
+		// A clean submission still passes: neither bad entry broke the pipeline.
+		$this->assertTrue(
+			Guard_Runner::run(
+				[
+					'content'                        => 'ordinary text',
+					'simple_spam_shield_website_url' => '',
+					'simple_spam_shield_form_loaded' => $this->token(),
+				],
+				'comment'
+			)
+		);
+	}
+
+	public function test_a_builtin_guard_can_be_removed_by_filter(): void {
+		add_filter(
+			'simple_spam_shield_guards',
+			static function ( array $defs ): array {
+				unset( $defs['honeypot'] );
+				return $defs;
+			}
+		);
+		Guard_Runner::init();
+
+		// With the honeypot gone, a filled trap no longer blocks.
+		$this->assertTrue(
+			Guard_Runner::run(
+				[
+					'content'                        => 'ordinary text',
+					'simple_spam_shield_website_url' => 'http://bot.example',
+					'simple_spam_shield_form_loaded' => $this->token(),
+				],
+				'comment'
+			)
+		);
+	}
+
+	public function test_blocked_action_fires_with_every_matched_guard(): void {
+		Guard_Runner::init();
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_blocked_keywords'] = 'casino';
+
+		$seen = [];
+		add_action(
+			'simple_spam_shield_blocked',
+			static function ( $guard, $context, $matched, $data ) use ( &$seen ): void {
+				$seen = compact( 'guard', 'context', 'matched', 'data' );
+			}
+		);
+
+		Guard_Runner::run(
+			[
+				'content'                        => 'visit my casino',
+				'simple_spam_shield_website_url' => 'http://bot.example',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertSame( 'honeypot', $seen['guard'] );
+		$this->assertSame( 'comment', $seen['context'] );
+		$this->assertContains( 'honeypot', $seen['matched'] );
+		$this->assertContains( 'keyword_block', $seen['matched'] );
+		$this->assertSame( $seen['guard'], $seen['matched'][0] );
+	}
+
+	/** A filter returning nonsense must not disable every guard. */
+	public function test_a_filter_returning_a_non_array_falls_back_to_the_builtins(): void {
+		add_filter( 'simple_spam_shield_guards', static fn() => 'not an array' );
+		Guard_Runner::init();
+
+		$this->assertSame( 8, count( Guard_Runner::definitions() ) );
+
+		// The honeypot still blocks, so protection was not lost.
+		$this->assertInstanceOf(
+			WP_Error::class,
+			Guard_Runner::run(
+				[
+					'content'                        => 'ordinary text',
+					'simple_spam_shield_website_url' => 'http://bot.example',
+					'simple_spam_shield_form_loaded' => $this->token(),
+				],
+				'comment'
+			)
+		);
+	}
+
+	public function test_blocked_action_does_not_fire_for_a_clean_submission(): void {
+		Guard_Runner::init();
+		$fired = false;
+		add_action( 'simple_spam_shield_blocked', static function () use ( &$fired ): void { $fired = true; } );
+
+		Guard_Runner::run(
+			[
+				'content'                        => 'ordinary text',
+				'simple_spam_shield_website_url' => '',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertFalse( $fired );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -125,6 +125,31 @@ if ( ! function_exists( 'apply_filters' ) ) {
 		return $value;
 	}
 }
+// --- In-memory action registry -----------------------------------------------
+// In WordPress actions and filters share a mechanism, but actions take no
+// return value, so they get their own store here to keep the stubs honest.
+$GLOBALS['simple_spam_shield_test_actions'] = [];
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['simple_spam_shield_test_actions'][ $hook ][] = $callback;
+		return true;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		foreach ( $GLOBALS['simple_spam_shield_test_actions'][ $hook ] ?? [] as $callback ) {
+			$callback( ...$args );
+		}
+	}
+}
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( $function_name, $message, $version ) {
+		// Recorded rather than emitted: these are deliberate in some tests.
+		$GLOBALS['simple_spam_shield_test_doing_it_wrong'][] = compact( 'function_name', 'message', 'version' );
+	}
+}
+
 if ( ! function_exists( 'wp_die' ) ) {
 	function wp_die( $message = '', $title = '', $args = [] ) {
 		// Throw instead of exiting so tests can assert the hard-block path.


### PR DESCRIPTION
Closes #6. Completes the 1.3.0 milestone and bumps the version to 1.3.0.

## What this adds

`Guard_Runner::definitions()` is now the single source of truth for what the pipeline runs. It builds the built-in definitions, attaches each class, and applies a new `simple_spam_shield_guards` filter. `init()` and `Admin::register_settings()` both read it, so a guard registered by another plugin is sorted by weight, short-circuits like any other, is recorded in the log, and gets its own toggle on the Guards tab without any extra registration.

```php
add_filter( "simple_spam_shield_guards", function ( array $guards ) {
    $guards["acme_blocklist"] = [
        "class"              => \Acme\Blocklist_Guard::class,
        "label"              => "Acme blocklist",
        "weight"             => 65,
        "enabled_by_default" => true,
    ];
    return $guards;
} );
```

A new `simple_spam_shield_blocked` action fires after a block is logged, carrying the deciding guard, the context, every guard that matched, and the submitted data (documented as personal data).

## Failure modes are deliberate about what they fall back to

A class not implementing `Guard_Interface` is skipped with `_doing_it_wrong()`. A filter returning a non-array falls back to the **built-in definitions**, not an empty list — falling back to empty would silently disable every guard and leave the site unprotected because of someone else's bug. There is a regression test that fails against the empty-list version.

## Verified on a live install

Registered a guard from a temporary mu-plugin on the local site. It appeared in `definitions()`, sorted into the pipeline at its weight, and was recorded in `guards_matched` alongside two built-ins:

```
guards_matched: duplicate,osg_live_test,link_limit
```

The probe and its log rows were removed afterwards and the site returned to 8 guards.

## A correction this surfaced

That same run showed the 1.3.0 changelog claimed more than the code delivers. A guard is only put in observe mode once an *earlier* guard has decided the block, and `Duplicate` runs at weight 95 with only `Honeypot` above it — so a submission blocked by any of the six lower-weight guards is still recorded, and an identical resubmission is refused as a duplicate with a misleading message:

```
1st submission blocked by: simple_spam_shield_link_limit_failed
2nd (identical) blocked by: simple_spam_shield_duplicate_failed
```

`CHANGELOG.md` and `readme.txt` now describe the actual behaviour. The real fix needs a commit step separate from the check and is filed as #26 against 1.4.0.

## Also

`build/` is excluded from phpcs. It is gitignored, so CI never saw it, but locally a `bin/build-dist.sh` run made the gate fail with duplicate-class warnings on a copy of the source.

## Gate

| Check | Result |
| --- | --- |
| `bin/check-versions.sh` | 7/7 consistent at 1.3.0 |
| `bin/check-pot.sh` | up to date, 80 strings |
| PHPStan level 5 | no errors |
| PHPUnit | 104 tests, 191 assertions |
| PHPCS (WPCS) | clean |
| Plugin Check (built package) | no errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)