### PR TITLE
Split guard evaluation from recording (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The user-facing changelog shipped to WordPress.org lives in the
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-08-21
+## [1.3.0] - 2026-08-22
 
 ### Added
 - Other plugins can register their own guard through the new
@@ -29,23 +29,34 @@ The user-facing changelog shipped to WordPress.org lives in the
   not just the first one to fire. The guard that decided the outcome is still
   shown on its own line in the log viewer, with any additional matches listed
   beneath it, so the guard filter and the 7-day summary are unchanged.
-- `Guard_Interface::check()` takes a third `$observe_only` argument. The runner
-  keeps its short-circuit for the *verdict* — the highest-weight failure still
-  decides the outcome and the message the visitor sees — but continues
-  evaluating the remaining guards for the record. Guards called that way must
-  not change state.
+- `Guard_Interface` splits evaluation from recording. `check( $data, $context )`
+  evaluates and is called whatever the outcome, so the log can record every
+  guard that matched; the runner keeps its short-circuit for the *verdict*, so
+  the highest-weight failure still decides what the visitor sees. The new
+  `commit( $data, $context )` runs on every enabled guard only once no guard has
+  objected, and is where state describing an accepted submission belongs.
+  `Abstract_Guard::commit()` is an empty default, so guards holding no state are
+  unaffected.
 
 ### Changed
-- `Duplicate` and `Rate_Limit` skip their transient writes while observing, so a
-  submission already blocked by a higher-weight guard no longer registers itself
-  in the duplicate cache and no longer consumes rate-limit budget.
+- `Duplicate` now records on commit instead of during its check, fixing a bug
+  where a submission rejected by any lower-weight guard was still entered in the
+  duplicate cache. A visitor who fixed whatever tripped them and resubmitted was
+  then refused a second time as a duplicate of their own blocked attempt, naming
+  the wrong reason. Only `Honeypot` outranks `Duplicate`, so this affected
+  rejections from six of the eight guards.
+- `Rate_Limit` now counts every attempt, including rejected ones — the opposite
+  correction, for the opposite reason. It sits below `Honeypot`, so it was
+  previously never counting the traffic it exists to throttle: a bot could flood
+  a form indefinitely without consuming any budget, while a legitimate visitor
+  who tripped a guard once did consume it. The limiter was effectively
+  throttling only real users.
 
-  Note the limit of this: a guard only observes once some *earlier* guard has
-  decided the block. `Duplicate` runs at weight 95 with only `Honeypot` above it,
-  so a submission blocked by any of the six lower-weight guards has already been
-  recorded by the time the block happens, and an identical resubmission is then
-  refused as a duplicate. Recording only submissions that clear the whole
-  pipeline needs a separate commit step and is tracked as its own issue.
+  Both of these are bugs in released code, not regressions introduced during
+  this cycle. In 1.2.1 the runner returned on the first failure, so `Rate_Limit`
+  never ran once a higher-weight guard had blocked, and `Duplicate` recorded
+  unconditionally inside its check. Sites running 1.2.0 or 1.2.1 with either
+  guard enabled are affected.
 - Database schema 1.1 -> 1.2 adds a `guards_matched` column, applied by
   `dbDelta` on upgrade. Existing rows are preserved and simply carry an empty
   value.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,20 +112,33 @@ so guards never need to know about comment arrays vs. Jetpack field data.
    namespace Simple_Spam_Shield\Guards;
 
    final class My_Guard extends Abstract_Guard {
-       public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+       public function check( array $data, string $context ): \WP_Error|true {
            // Return true to pass, or $this->fail( $message ) to block.
        }
    }
    ```
 
-   **`$observe_only` matters if your guard changes state.** The runner keeps
-   evaluating after a submission has already been blocked, so the log can record
-   every guard that matched rather than only the first. Guards called that way
-   must return their verdict *without* writing anything — no transients, no
-   options, no queries that mutate. `Duplicate` and `Rate_Limit` are the worked
-   examples: both put their write on the pass path behind
-   `if ( ! $observe_only )`. The verdict must be identical either way. A guard
-   with no side effects can ignore the flag.
+   **A guard is evaluated whatever the outcome.** The runner keeps going after a
+   submission has been blocked, so the log can record every guard that matched
+   rather than only the first. `check()` must return the same verdict either
+   way.
+
+   **State goes in `commit()`, not `check()`.** The runner calls `commit()` on
+   every enabled guard only once no guard has objected, so a guard never records
+   a submission that something else rejected. `Abstract_Guard::commit()` is an
+   empty default; override it only if your guard remembers something.
+
+   The two built-in state-holding guards sit on opposite sides of this on
+   purpose, and the reasoning is worth understanding before adding a third:
+
+   | Guard | Question it asks | Records |
+   | --- | --- | --- |
+   | `Duplicate` | have I already *taken* this content? | in `commit()` — a rejected submission was never taken |
+   | `Rate_Limit` | is this sender *hammering* the form? | in `check()` — a rejected attempt is still an attempt |
+
+   Getting `Rate_Limit` the other way round means a bot can flood the form
+   forever without ever consuming budget, while a legitimate visitor who trips a
+   guard once does consume it — the limiter ends up throttling only real users.
 
    The file/class naming follows the autoloader: `My_Guard` →
    `class-my-guard.php`.
@@ -154,11 +167,6 @@ implementation is refused with `_doing_it_wrong()`, and a filter that returns a
 non-array leaves the built-in guards in place rather than dropping the site's
 protection. Keep `definitions()` the single source of truth for what the
 pipeline runs, so a registered guard is never a second-class citizen.
-
-**Known limitation:** the runner only puts a guard in observe mode once an
-*earlier* guard has decided the block, so `Duplicate` and `Rate_Limit` still
-record submissions rejected by a lower-weight guard. Tracked in issue #26; a new
-state-holding guard inherits the same caveat.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -173,21 +173,34 @@ add_filter( 'simple_spam_shield_guards', function ( array $guards ) {
 Register it when your plugin file loads, so the filter is in place before the
 pipeline is built on `plugins_loaded`.
 
-Your guard must honour the third argument to `check()`:
+Your guard is evaluated even when an earlier guard has already blocked, so the
+log can record every guard that matched. `check()` must therefore return the
+same verdict whatever the outcome. Anything you want to remember about a
+submission goes in `commit()`, which the runner calls only once no guard has
+objected:
 
 ```php
-public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
-    // ... decide ...
-    if ( ! $observe_only ) {
-        // only now may you write transients, options, or rows
-    }
+public function check( array $data, string $context ): \WP_Error|true {
+    // Evaluate only. Called whatever the outcome, so no side effects that
+    // assume the submission was accepted.
+}
+
+public function commit( array $data, string $context ): void {
+    // The submission cleared every guard. Record it here.
 }
 ```
 
-The runner keeps evaluating after a submission has already been blocked so the
-log can record every guard that matched. Guards called that way must return the
-same verdict **without changing any state** — see `Duplicate` and `Rate_Limit`
-for worked examples.
+`Abstract_Guard::commit()` is an empty default, so a guard holding no state can
+simply omit it.
+
+The distinction is the difference between two questions. `Duplicate` asks "have
+I already taken this exact content?", so it records on commit — a submission
+some other guard rejected was never taken, and recording it would refuse the
+visitor who fixed the problem and resubmitted. `Rate_Limit` asks "is this sender
+hammering the form?", so it counts inside `check()`, including rejected
+attempts: a flooding sender is overwhelmingly being rejected by some other
+guard, and counting only what got through would let a bot flood forever while
+still charging a legitimate visitor for one mistake.
 
 The same filter can adjust or remove a built-in guard by editing or unsetting
 its entry.

--- a/includes/core/class-guard-runner.php
+++ b/includes/core/class-guard-runner.php
@@ -113,10 +113,11 @@ final class Guard_Runner {
 		 * Hook this before `plugins_loaded` priority 10 — registering it when
 		 * your plugin file loads is the usual way.
 		 *
-		 * A registered guard must honour the `$observe_only` argument to
-		 * `check()`: the runner keeps evaluating after a submission has already
-		 * been blocked so the log can record every guard that matched, and
-		 * guards called that way must not change any state.
+		 * A registered guard is evaluated even after another guard has blocked,
+		 * so the log can record every guard that matched. `check()` must
+		 * therefore return the same verdict whatever the outcome. State
+		 * describing an *accepted* submission belongs in `commit()`, which the
+		 * runner calls only once no guard has objected.
 		 *
 		 * @since 1.3.0
 		 *
@@ -151,19 +152,20 @@ final class Guard_Runner {
 
 		$verdict = null;
 		$matched = [];
+		$enabled = [];
 
 		foreach ( self::$guards as $guard ) {
 			if ( ! $guard->is_enabled() ) {
 				continue;
 			}
 
-			// Once a guard has blocked, the remaining ones are evaluated for
-			// the record only: their verdict is collected but they must not
-			// change any state. The submission's fate was decided by the first
-			// failure, so nothing here can alter what the visitor sees.
-			$observe_only = null !== $verdict;
+			// Every enabled guard is evaluated even once one has blocked, so the
+			// log can record each guard that matched rather than only the first.
+			// The verdict is still decided by the highest-weight failure, so
+			// nothing evaluated later changes what the visitor sees.
+			$enabled[] = $guard;
 
-			$result = $guard->check( $data, $context, $observe_only );
+			$result = $guard->check( $data, $context );
 
 			if ( ! is_wp_error( $result ) ) {
 				continue;
@@ -177,7 +179,14 @@ final class Guard_Runner {
 			}
 		}
 
+		// Nothing objected: tell the guards the submission was accepted, so the
+		// ones holding state record it. Doing this only now is the whole point —
+		// a guard must not record a submission that some later guard rejects.
 		if ( null === $verdict ) {
+			foreach ( $enabled as $guard ) {
+				$guard->commit( $data, $context );
+			}
+
 			return true;
 		}
 

--- a/includes/guards/class-abstract-guard.php
+++ b/includes/guards/class-abstract-guard.php
@@ -32,6 +32,17 @@ abstract class Abstract_Guard implements Guard_Interface {
 	}
 
 	/**
+	 * Record an accepted submission.
+	 *
+	 * Empty by default: most guards read state rather than write it. Guards that
+	 * must remember an accepted submission — `Duplicate` — override this.
+	 *
+	 * @param array  $data    Submission data, as passed to check().
+	 * @param string $context Submission context.
+	 */
+	public function commit( array $data, string $context ): void {} // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- Deliberate no-op default for guards that hold no state.
+
+	/**
 	 * Helper: build a WP_Error for a failed guard.
 	 */
 	protected function fail( string $message ): \WP_Error {

--- a/includes/guards/class-behavioral.php
+++ b/includes/guards/class-behavioral.php
@@ -16,7 +16,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Behavioral extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$json = $data['simple_spam_shield_behavioral_data'] ?? '';
 
 		// If the behavioral data field is missing (e.g. Jetpack strips it),

--- a/includes/guards/class-duplicate.php
+++ b/includes/guards/class-duplicate.php
@@ -15,32 +15,46 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Duplicate extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
-		$content = $data['content'] ?? $data['comment'] ?? '';
-		$author  = $data['author'] ?? $data['author_name'] ?? '';
-		$email   = $data['email'] ?? $data['author_email'] ?? '';
-		$ip      = \Simple_Spam_Shield\Core\Request::ip();
-
-		$hash = md5( $content . $author . $email . $ip );
-
-		$transient_key = 'simple_spam_shield_dup_' . $hash;
-		$window        = (int) ( $this->config['window_seconds'] ?? 60 );
-
-		if ( get_transient( $transient_key ) ) {
+	public function check( array $data, string $context ): \WP_Error|true {
+		if ( get_transient( self::transient_key( $data ) ) ) {
 			return $this->fail(
 				__( 'Duplicate submission detected — please wait before resubmitting.', 'onsite-spam-guard' )
 			);
 		}
 
-		// Mark this submission as seen for the duration of the window. Skipped
-		// when only observing, so a submission already blocked by an earlier
-		// guard does not register itself — otherwise a visitor who fixed
-		// whatever tripped them and resubmitted the same content would be
-		// rejected as a duplicate of their own blocked attempt.
-		if ( ! $observe_only ) {
-			set_transient( $transient_key, time(), $window );
-		}
-
 		return true;
+	}
+
+	/**
+	 * Register an accepted submission for the duration of the window.
+	 *
+	 * This deliberately happens on commit rather than during check(): the guard
+	 * asks "have I already taken this exact content?", and a submission some
+	 * other guard rejected was never taken. Recording it during the check would
+	 * refuse a visitor who fixed whatever tripped them and resubmitted, naming
+	 * a duplicate of their own blocked attempt as the reason.
+	 *
+	 * @param array  $data    Submission data.
+	 * @param string $context Submission context.
+	 */
+	public function commit( array $data, string $context ): void {
+		$window = (int) ( $this->config['window_seconds'] ?? 60 );
+
+		set_transient( self::transient_key( $data ), time(), $window );
+	}
+
+	/**
+	 * Transient key identifying a submission, so check() and commit() cannot
+	 * drift apart on how a submission is fingerprinted.
+	 *
+	 * @param array $data Submission data.
+	 */
+	private static function transient_key( array $data ): string {
+		$content = $data['content'] ?? $data['comment'] ?? '';
+		$author  = $data['author'] ?? $data['author_name'] ?? '';
+		$email   = $data['email'] ?? $data['author_email'] ?? '';
+		$ip      = \Simple_Spam_Shield\Core\Request::ip();
+
+		return 'simple_spam_shield_dup_' . md5( $content . $author . $email . $ip );
 	}
 }

--- a/includes/guards/class-guard-interface.php
+++ b/includes/guards/class-guard-interface.php
@@ -14,23 +14,39 @@ interface Guard_Interface {
 	/**
 	 * Run the spam check.
 	 *
-	 * When $observe_only is true the guard MUST return its verdict without
-	 * changing any state: no transients, no options, no database writes. The
-	 * runner uses this to keep evaluating after a submission has already been
-	 * blocked, so the log can record every guard that matched rather than only
-	 * the first — without a blocked submission consuming rate-limit budget or
-	 * registering itself in the duplicate cache.
+	 * The runner keeps evaluating after a submission has already been blocked,
+	 * so the log can record every guard that matched rather than only the first.
+	 * A guard is therefore called whatever the outcome, and must return the same
+	 * verdict for the same input either way.
 	 *
-	 * The verdict must be identical in both modes. Guards with no side effects
-	 * can ignore the flag entirely.
+	 * A guard may record the *attempt* here — `Rate_Limit` counts every
+	 * submission a sender makes, including rejected ones, because a rejected
+	 * attempt is still an attempt and is the main thing worth throttling.
+	 * Anything that should only be recorded once a submission is *accepted*
+	 * belongs in commit() instead.
 	 *
-	 * @param array  $data         Submission data.
-	 * @param string $context      'comment' | 'woo_review' | 'jetpack_form', or a
-	 *                             custom label from simple_spam_shield_check().
-	 * @param bool   $observe_only Evaluate without mutating state.
+	 * @param array  $data    Submission data.
+	 * @param string $context 'comment' | 'woo_review' | 'jetpack_form', or a
+	 *                        custom label from simple_spam_shield_check().
 	 * @return \WP_Error|true  True on pass, WP_Error on fail.
 	 */
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true;
+	public function check( array $data, string $context ): \WP_Error|true;
+
+	/**
+	 * Record that a submission cleared the whole pipeline.
+	 *
+	 * Called once, on every enabled guard, only after no guard objected. This is
+	 * where state describing an *accepted* submission belongs — `Duplicate`
+	 * registers the content here, so a visitor rejected by some other guard is
+	 * not then refused as a duplicate of their own blocked attempt.
+	 *
+	 * Guards holding no such state do nothing; `Abstract_Guard` provides an
+	 * empty default so only the guards that need it override this.
+	 *
+	 * @param array  $data    Submission data, as passed to check().
+	 * @param string $context Submission context.
+	 */
+	public function commit( array $data, string $context ): void;
 
 	/**
 	 * Whether this guard is enabled in settings.

--- a/includes/guards/class-honeypot.php
+++ b/includes/guards/class-honeypot.php
@@ -22,7 +22,7 @@ final class Honeypot extends Abstract_Guard {
 	 */
 	public const FIELD = 'simple_spam_shield_website_url';
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		// If the honeypot field is present and non-empty, it's a bot.
 		if ( ! empty( $data[ self::FIELD ] ) ) {
 			return $this->fail(

--- a/includes/guards/class-keyword-block.php
+++ b/includes/guards/class-keyword-block.php
@@ -18,7 +18,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Keyword_Block extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$content = $data['content'] ?? $data['comment'] ?? '';
 		$author  = $data['author'] ?? $data['author_name'] ?? '';
 		$email   = $data['email'] ?? $data['author_email'] ?? '';

--- a/includes/guards/class-link-limit.php
+++ b/includes/guards/class-link-limit.php
@@ -11,7 +11,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Link_Limit extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$max_links = (int) get_option( 'simple_spam_shield_link_limit_max', $this->config['max_links'] ?? 3 );
 		$content   = $data['content'] ?? $data['comment'] ?? '';
 

--- a/includes/guards/class-nonce.php
+++ b/includes/guards/class-nonce.php
@@ -23,7 +23,7 @@ final class Nonce extends Abstract_Guard {
 
 	public const FIELD = 'simple_spam_shield_form_loaded';
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$token = (string) ( $data[ self::FIELD ] ?? '' );
 
 		if ( '' === $token ) {

--- a/includes/guards/class-rate-limit.php
+++ b/includes/guards/class-rate-limit.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class Rate_Limit extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$max = (int) get_option( 'simple_spam_shield_rate_limit_max', $this->config['max_per_window'] ?? 10 );
 
 		// A max of 0 (or less) disables the limit.
@@ -43,13 +43,15 @@ final class Rate_Limit extends Abstract_Guard {
 			);
 		}
 
-		// Rolling window: each accepted submission extends the window, so a
-		// persistent sender stays throttled until they pause for $window.
-		// Skipped when only observing: the count should reflect submissions
-		// that got through, not ones an earlier guard already rejected.
-		if ( ! $observe_only ) {
-			set_transient( $key, $count + 1, $window );
-		}
+		// Rolling window: every attempt extends the window, so a persistent
+		// sender stays throttled until they pause for $window.
+		//
+		// This counts rejected attempts too, and deliberately so. The limiter
+		// exists to throttle a sender hammering the form, and such a sender is
+		// overwhelmingly being rejected by some other guard — counting only what
+		// got through would leave a bot free to flood the form forever while
+		// still charging a legitimate visitor for a single mistake.
+		set_transient( $key, $count + 1, $window );
 
 		return true;
 	}

--- a/includes/guards/class-time-gate.php
+++ b/includes/guards/class-time-gate.php
@@ -11,7 +11,7 @@ namespace Simple_Spam_Shield\Guards;
 
 final class Time_Gate extends Abstract_Guard {
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
+	public function check( array $data, string $context ): \WP_Error|true {
 		$min_seconds = (int) get_option( 'simple_spam_shield_time_gate_seconds', $this->config['min_seconds'] ?? 3 );
 
 		$token = (string) ( $data['simple_spam_shield_form_loaded'] ?? '' );

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-21T22:34:18+00:00\n"
+"POT-Creation-Date: 2026-08-22T17:37:25+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Submission rejected — suspicious activity detected."
 msgstr ""
 
-#: includes/guards/class-duplicate.php:31
+#: includes/guards/class-duplicate.php:21
 msgid "Duplicate submission detected — please wait before resubmitting."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,8 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 
 = 1.3.0 =
 * The spam log now records every guard that matched a blocked submission, not just the first one. The guard that decided the outcome is still shown on its own line, with any additional matches listed beneath it.
-* A submission caught by the honeypot no longer counts against the duplicate and rate-limit guards, so it cannot use up a real visitor's allowance.
+* Fixed: a submission rejected by one guard was recorded as "seen" by the duplicate guard, so a visitor who corrected the problem and resubmitted was refused a second time — told they had submitted a duplicate rather than what was actually wrong.
+* Fixed: the rate limit was not counting submissions that another guard had already rejected, which is most of what a spam bot sends. A bot could keep submitting indefinitely without ever reaching the limit, while a legitimate visitor who tripped a guard once did count against it. Rejected attempts now count.
 * For developers: other plugins can now register their own guard through the simple_spam_shield_guards filter. A registered guard runs in the pipeline, appears in the log, and gets its own toggle on the Guards tab. A new simple_spam_shield_blocked action fires whenever a submission is blocked. See the readme in the plugin's repository.
 
 = 1.2.1 =
@@ -148,7 +149,7 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 == Upgrade Notice ==
 
 = 1.3.0 =
-Adds an upgrade to the database table for the richer spam log. Existing log entries are kept. Nothing needs to be reconfigured.
+Recommended if you use the duplicate or rate-limit guard: both were recording the wrong submissions, which let a bot bypass the rate limit and could refuse a genuine visitor as a duplicate. Upgrades the log table; existing entries are kept and nothing needs reconfiguring.
 
 = 1.2.1 =
 Fixes IPv6 allowlist entries being ignored, plus two smaller issues. Recommended if you allowlist by IP range.

--- a/tests/DuplicateTest.php
+++ b/tests/DuplicateTest.php
@@ -23,7 +23,25 @@ final class DuplicateTest extends TestCase {
 			'email'   => 'bob@example.com',
 		];
 		$this->assertTrue( $this->guard()->check( $data, 'comment' ) );
+
+		// The runner commits once no guard has objected; that is what records
+		// the submission, not the check itself.
+		$this->guard()->commit( $data, 'comment' );
+
 		$this->assertInstanceOf( WP_Error::class, $this->guard()->check( $data, 'comment' ) );
+	}
+
+	/** Checking without committing must leave nothing behind. */
+	public function test_a_check_alone_never_records_the_submission(): void {
+		$data = [
+			'content' => 'hello there',
+			'author'  => 'Bob',
+			'email'   => 'bob@example.com',
+		];
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->assertTrue( $this->guard()->check( $data, 'comment' ), "check {$i} recorded the submission" );
+		}
 	}
 
 	public function test_allows_a_different_submission(): void {
@@ -33,6 +51,7 @@ final class DuplicateTest extends TestCase {
 			'email'   => 'bob@example.com',
 		];
 		$this->assertTrue( $this->guard()->check( $first, 'comment' ) );
+		$this->guard()->commit( $first, 'comment' );
 
 		$second            = $first;
 		$second['content'] = 'a completely different message';
@@ -46,6 +65,7 @@ final class DuplicateTest extends TestCase {
 			'email'   => 'bob@example.com',
 		];
 		$this->assertTrue( $this->guard()->check( $data, 'comment' ) );
+		$this->guard()->commit( $data, 'comment' );
 
 		// The same content from a different IP is not a duplicate.
 		$_SERVER['REMOTE_ADDR'] = '203.0.113.9';

--- a/tests/EvaluateAllGuardsTest.php
+++ b/tests/EvaluateAllGuardsTest.php
@@ -44,44 +44,41 @@ final class EvaluateAllGuardsTest extends TestCase {
 
 	// --- the guards themselves -------------------------------------------
 
-	public function test_duplicate_does_not_record_the_submission_when_observing(): void {
+	public function test_duplicate_records_only_on_commit(): void {
 		$guard = new Duplicate( 'duplicate', [ 'window_seconds' => 60 ] );
 		$data  = [ 'content' => 'hello', 'author' => 'A', 'email' => 'a@example.com' ];
 
-		$this->assertTrue( $guard->check( $data, 'comment', true ) );
-		// Observing must leave no trace, so the same content still passes.
-		$this->assertTrue( $guard->check( $data, 'comment', true ) );
-
-		// A real (non-observing) pass does record it.
+		// Checking alone leaves no trace, however many times it happens.
 		$this->assertTrue( $guard->check( $data, 'comment' ) );
+		$this->assertTrue( $guard->check( $data, 'comment' ) );
+
+		// Only an accepted submission is recorded.
+		$guard->commit( $data, 'comment' );
 		$this->assertInstanceOf( WP_Error::class, $guard->check( $data, 'comment' ) );
 	}
 
-	public function test_rate_limit_does_not_consume_budget_when_observing(): void {
+	public function test_rate_limit_counts_every_attempt_including_rejected_ones(): void {
 		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max'] = 2;
 		$guard = new Rate_Limit( 'rate_limit', [ 'max_per_window' => 2, 'window_seconds' => 60 ] );
 
-		for ( $i = 0; $i < 10; $i++ ) {
-			$this->assertTrue( $guard->check( [], 'comment', true ), "observation {$i} consumed budget" );
-		}
-
-		// Budget is untouched, so two real submissions still pass.
+		// The limiter throttles a sender by attempts, so no commit is involved.
 		$this->assertTrue( $guard->check( [], 'comment' ) );
 		$this->assertTrue( $guard->check( [], 'comment' ) );
 		$this->assertInstanceOf( WP_Error::class, $guard->check( [], 'comment' ) );
 	}
 
-	public function test_verdict_is_identical_in_both_modes(): void {
+	public function test_rate_limit_keeps_failing_once_the_window_is_spent(): void {
 		$guard = new Rate_Limit( 'rate_limit', [ 'max_per_window' => 1, 'window_seconds' => 60 ] );
 		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max'] = 1;
 
-		$guard->check( [], 'comment' );                    // consume the single slot
-		$observed = $guard->check( [], 'comment', true );
-		$real     = $guard->check( [], 'comment' );
+		$guard->check( [], 'comment' );   // consume the single slot
 
-		$this->assertInstanceOf( WP_Error::class, $observed );
-		$this->assertInstanceOf( WP_Error::class, $real );
-		$this->assertSame( $real->get_error_code(), $observed->get_error_code() );
+		$first  = $guard->check( [], 'comment' );
+		$second = $guard->check( [], 'comment' );
+
+		$this->assertInstanceOf( WP_Error::class, $first );
+		$this->assertInstanceOf( WP_Error::class, $second );
+		$this->assertSame( $first->get_error_code(), $second->get_error_code() );
 	}
 
 	// --- the runner -------------------------------------------------------
@@ -112,28 +109,81 @@ final class EvaluateAllGuardsTest extends TestCase {
 	}
 
 	/**
-	 * A blocked submission must not consume rate-limit budget on its way out.
-	 * Before observe-only this was impossible to get wrong, because the
-	 * rate-limit guard never ran once an earlier guard had blocked.
+	 * A submission rejected by another guard must not land in the duplicate
+	 * cache — otherwise the visitor fixes the problem, resubmits, and is
+	 * refused as a duplicate of their own blocked attempt, naming the wrong
+	 * reason. This is the regression #26 was filed for.
 	 */
-	public function test_blocked_submission_does_not_consume_rate_limit_budget(): void {
-		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max']     = 2;
+	public function test_a_blocked_submission_is_not_recorded_as_a_duplicate(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_duplicate_enabled']  = true;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_enabled'] = true;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max']     = 3;
+
+		// Tripped by link_limit (weight 70), well below duplicate (95).
+		$spammy = [
+			'content'                        => 'hi http://a.example http://b.example http://c.example http://d.example',
+			'simple_spam_shield_website_url' => '',
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+
+		$first = Guard_Runner::run( $spammy, 'comment' );
+		$this->assertSame( 'simple_spam_shield_link_limit_failed', $first->get_error_code() );
+
+		// Resubmitting the identical text must still name the real problem.
+		$second = Guard_Runner::run( $spammy, 'comment' );
+		$this->assertSame(
+			'simple_spam_shield_link_limit_failed',
+			$second->get_error_code(),
+			'a blocked submission was recorded in the duplicate cache'
+		);
+
+		// And the corrected version goes through.
+		$fixed = [
+			'content'                        => 'hi http://a.example',
+			'simple_spam_shield_website_url' => '',
+			'simple_spam_shield_form_loaded' => $this->token(),
+		];
+		$this->assertTrue( Guard_Runner::run( $fixed, 'comment' ) );
+	}
+
+	/**
+	 * The inverse, and the reason Rate_Limit is not moved to commit(): a sender
+	 * flooding the form is overwhelmingly being rejected by some other guard.
+	 * Counting only accepted submissions would let a bot flood forever while
+	 * still charging a legitimate visitor for a single mistake.
+	 */
+	public function test_a_flooder_blocked_by_another_guard_still_consumes_rate_limit_budget(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_max']     = 3;
 		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_rate_limit_enabled'] = true;
 
-		$blocked = [
-			'content'                        => 'hello',
+		// Every attempt trips the honeypot (weight 100), above rate_limit (85).
+		$flood = [
+			'content'                        => 'flood',
 			'simple_spam_shield_website_url' => 'http://bot.example',
 			'simple_spam_shield_form_loaded' => $this->token(),
 		];
-		for ( $i = 0; $i < 5; $i++ ) {
-			$this->assertInstanceOf( WP_Error::class, Guard_Runner::run( $blocked, 'comment' ) );
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->assertSame(
+				'simple_spam_shield_honeypot_failed',
+				Guard_Runner::run( $flood, 'comment' )->get_error_code()
+			);
 		}
 
+		// The honeypot keeps deciding the verdict for the bot's own traffic, as
+		// it should — it outranks the limiter. What proves the attempts were
+		// counted is that the sender's budget is now spent, so even a submission
+		// with nothing wrong with it is throttled.
 		$clean = [
 			'content'                        => 'an ordinary comment',
 			'simple_spam_shield_website_url' => '',
 			'simple_spam_shield_form_loaded' => $this->token(),
 		];
-		$this->assertTrue( Guard_Runner::run( $clean, 'comment' ) );
+		$result = Guard_Runner::run( $clean, 'comment' );
+		$this->assertSame(
+			'simple_spam_shield_rate_limit_failed',
+			$result->get_error_code(),
+			'a flooding sender was never charged for rejected attempts'
+		);
 	}
+
 }

--- a/tests/GuardRegistrationTest.php
+++ b/tests/GuardRegistrationTest.php
@@ -8,16 +8,19 @@ use Simple_Spam_Shield\Guards\Abstract_Guard;
 
 /** A guard supplied by a hypothetical third-party plugin. */
 final class Test_External_Guard extends Abstract_Guard {
-	public static int $observed_calls = 0;
+	public static int $checked_calls = 0;
+	public static int $commit_calls  = 0;
 
-	public function check( array $data, string $context, bool $observe_only = false ): \WP_Error|true {
-		if ( $observe_only ) {
-			++self::$observed_calls;
-		}
+	public function check( array $data, string $context ): \WP_Error|true {
+		++self::$checked_calls;
 		if ( str_contains( (string) ( $data['content'] ?? '' ), 'forbidden-by-external' ) ) {
 			return $this->fail( 'Blocked by the external guard.' );
 		}
 		return true;
+	}
+
+	public function commit( array $data, string $context ): void {
+		++self::$commit_calls;
 	}
 }
 
@@ -40,7 +43,8 @@ final class GuardRegistrationTest extends TestCase {
 		$GLOBALS['simple_spam_shield_test_actions']    = [];
 		$_SERVER['REMOTE_ADDR']                        = '198.51.100.9';
 		$_POST                                         = [];
-		Test_External_Guard::$observed_calls           = 0;
+		Test_External_Guard::$checked_calls            = 0;
+		Test_External_Guard::$commit_calls             = 0;
 	}
 
 	private function token(): string {
@@ -108,8 +112,8 @@ final class GuardRegistrationTest extends TestCase {
 		$this->assertSame( 'simple_spam_shield_external_failed', $result->get_error_code() );
 	}
 
-	public function test_registered_guard_is_evaluated_in_observe_mode_after_a_block(): void {
-		// Below the honeypot, so the honeypot decides and this one only observes.
+	public function test_registered_guard_is_still_evaluated_after_another_guard_blocks(): void {
+		// Below the honeypot, so the honeypot decides the verdict first.
 		$this->registerExternalGuard( 10 );
 
 		Guard_Runner::run(
@@ -121,7 +125,24 @@ final class GuardRegistrationTest extends TestCase {
 			'comment'
 		);
 
-		$this->assertSame( 1, Test_External_Guard::$observed_calls );
+		$this->assertSame( 1, Test_External_Guard::$checked_calls, 'the guard should still be evaluated for the record' );
+		$this->assertSame( 0, Test_External_Guard::$commit_calls, 'a blocked submission must never be committed' );
+	}
+
+	public function test_commit_runs_on_every_enabled_guard_once_a_submission_is_accepted(): void {
+		$this->registerExternalGuard( 10 );
+
+		$result = Guard_Runner::run(
+			[
+				'content'                        => 'a perfectly ordinary message',
+				'simple_spam_shield_website_url' => '',
+				'simple_spam_shield_form_loaded' => $this->token(),
+			],
+			'comment'
+		);
+
+		$this->assertTrue( $result );
+		$this->assertSame( 1, Test_External_Guard::$commit_calls );
 	}
 
 	public function test_a_class_that_does_not_implement_the_contract_is_skipped(): void {


### PR DESCRIPTION
Closes #26, pulled into 1.3.0 so no released version ever carries the `$observe_only` shape.

## The interface, finalised

```php
public function check( array $data, string $context ): \WP_Error|true;  // evaluate
public function commit( array $data, string $context ): void;           // submission accepted; record it
```

`check()` is called whatever the outcome, so the log still records every guard that matched, and the verdict is still the highest-weight failure. `commit()` runs on every enabled guard only once nothing objected. `Abstract_Guard::commit()` is an empty default, so stateless guards are untouched. `$observe_only` is gone — once each guard was placed correctly it had no remaining user.

## The issue text was wrong, and the second guard was backwards

I filed #26 saying neither `Duplicate` nor `Rate_Limit` should record blocked submissions. Working through it, they want **opposite** things:

| Guard | Question | Records |
| --- | --- | --- |
| `Duplicate` | have I already *taken* this content? | `commit()` — a rejected submission was never taken |
| `Rate_Limit` | is this sender *hammering* the form? | `check()` — a rejected attempt is still an attempt |

`Rate_Limit` was the more serious of the two, and in the opposite direction from what I filed. Verified on the local install with the limit at 3, sending six honeypot-tripping submissions from one sender:

```
attempt 1 blocked by simple_spam_shield_honeypot_failed     rate count now: false
...
attempt 6 blocked by simple_spam_shield_honeypot_failed     rate count now: false
```

`Honeypot` is weight 100 and `Rate_Limit` 85, so the limiter was always skipped for exactly the traffic it exists to throttle. A bot could flood a form forever without consuming budget, while a legitimate visitor who tripped a guard once did consume it — the limiter was throttling only real users.

## These are bugs in released code

Not regressions from this cycle. `git show v1.2.1` confirms the runner returned on the first failure, so `Rate_Limit` never ran once a higher-weight guard had blocked, and `Duplicate` called `set_transient` unconditionally inside its check. **Sites on 1.2.0 or 1.2.1 with either guard enabled are affected**, so `readme.txt` describes both as fixes and the upgrade notice now recommends the update rather than just mentioning the schema change.

## Verified live, against the same probes that found the bugs

```
A. blocked submission must not become a duplicate
  attempt 1: simple_spam_shield_link_limit_failed
  attempt 2: simple_spam_shield_link_limit_failed     (was: duplicate_failed)
  corrected: ACCEPTED

B. flooding bot must consume rate budget
  flood 1/2/3: rate count = 1, 2, 3                   (was: false, false, false)
  clean submission from same sender: simple_spam_shield_rate_limit_failed
```

## Regression tests fail against the old behaviour in both directions

Re-introducing each old behaviour individually:

- `Duplicate` recording during `check()` → `test_a_blocked_submission_is_not_recorded_as_a_duplicate` reports the wrong guard, and `test_a_check_alone_never_records_the_submission` fails on the first check.
- `Rate_Limit` skipping rejected attempts → `test_a_flooder_blocked_by_another_guard_still_consumes_rate_limit_budget` never reaches the limit.

One assertion in the flood test needed correcting during development: I first asserted the bot itself gets a `rate_limit` verdict, but `Honeypot` outranks the limiter and rightly keeps deciding. What actually demonstrates the budget was consumed is a *clean* submission from the same sender being throttled.

## Also

- `Duplicate`s fingerprinting moved into a shared private helper, so `check()` and `commit()` cannot drift apart on how a submission is identified.
- `README.md` and `CONTRIBUTING.md` document the two-phase contract, including a table explaining why the two built-in state-holding guards sit on opposite sides of it — getting a future guard wrong the same way is the trap worth signposting.

## Gate

| Check | Result |
| --- | --- |
| `bin/check-versions.sh` | consistent at 1.3.0 |
| `bin/check-pot.sh` | up to date, 80 strings |
| PHPStan level 5 | no errors |
| PHPUnit | 107 tests, 189 assertions |
| PHPCS (WPCS) | clean |
| Plugin Check (built package) | no errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)