### PR TITLE
Watch GitHub Action versions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # GitHub Actions only.
+  #
+  # Deliberately no composer entry. `require` is just `php: >=8.2`, and
+  # .distignore drops /vendor, /composer.json and /composer.lock, so nothing
+  # Composer installs ever reaches the zip — every dependency here is dev
+  # tooling. Updating it would be churn on a solo-maintained plugin, and two of
+  # these are actively hostile to unattended bumps: a WPCS major surfaces new
+  # sniffs and a PHPStan major surfaces new errors, both failing CI without any
+  # change to shipped code.
+  #
+  # There is no package.json, so no npm ecosystem to watch.
+  #
+  # Action versions are the opposite case: they drift silently, and the only
+  # signal is a runner deprecation warning nobody reads until the action stops
+  # working. This repository is the one that is actually live on WordPress.org,
+  # so a release workflow that breaks on a retired action is the expensive
+  # version of that surprise.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      # One PR for the routine bumps; majors arrive separately so a breaking
+      # action change is reviewed on its own rather than buried in a batch.
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies


### PR DESCRIPTION
Brings this repository in step with the ShelterKit plugins, which already run
this config. One file; nothing that ships changes.

## Why Actions only

`require` is just `php: >=8.2`, and `.distignore` drops `/vendor`,
`/composer.json` and `/composer.lock` — so nothing Composer installs ever
reaches the zip. Every dependency here is dev tooling, and two are actively
hostile to unattended bumps: a WPCS major surfaces new sniffs and a PHPStan
major surfaces new errors, both failing CI without any change to shipped code.

There is no `package.json`, so no npm ecosystem to watch.

Action versions are the opposite case. They drift silently, and the only signal
is a runner deprecation warning nobody reads until the action stops working.

## Why here in particular

This is the plugin that is actually live on WordPress.org, so a release
workflow that breaks on a retired action is the expensive version of that
surprise — the failure would land the next time you try to publish, not at a
convenient moment.

It is also the furthest behind: still on `actions/checkout@v4`, while
ShelterKit Pets is on `@v7` and Donations was just brought up to date.

## What to expect after merging

Dependabot will open PRs on the next scheduled run. Given the current pins,
expect a major bump for `actions/checkout` (4 → 7) to arrive on its own, since
majors are deliberately not grouped.

Two notes from doing the same bumps on Donations:

- The workflow files *are* the changed files, so CI runs using the new action
  versions — a green run is real evidence rather than inference.
- `main` is protected with "require branches up to date", so each PR needs a
  rebase before merging, and merging one puts the next behind again.

The `Validate release` and `Publish` jobs only run on a tag, so any bump
touching `release.yml` is exercised at release time rather than by CI.