### PR TITLE
Add per-form threshold overrides (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ The user-facing changelog shipped to WordPress.org lives in the
 ## [Unreleased]
 
 ### Added
+- Per-form threshold overrides. Every guard threshold was global — one link
+  limit, one time gate, one rate limit — applied identically to comments,
+  WooCommerce reviews, Jetpack forms and anything integrated through the API, so
+  the only way to resolve a conflict between two forms was to loosen the setting
+  for both. A new **Per-form** settings tab overrides any of six thresholds per
+  context: minimum submit time, maximum links, duplicate window, rate-limit
+  maximum, rate-limit window, and behavioral threshold. A blank field inherits,
+  so one threshold can be changed without restating the rest.
+- `simple_spam_shield_contexts` filter, so a plugin protecting its own form
+  through `simple_spam_shield_check()` can register that form and have it appear
+  on the Per-form tab. Registration affects configurability only — an
+  unregistered form is still protected, using the global thresholds.
 - `simple_spam_shield_duplicate_window_seconds` and
   `simple_spam_shield_rate_limit_window_seconds` settings on the Guards tab.
   Both windows were fixed at 60 seconds in `config/guards.json` with no UI, so

--- a/README.md
+++ b/README.md
@@ -151,6 +151,42 @@ if ( function_exists( 'simple_spam_shield_field_markup' ) ) {
 
 Without step 2, only the content-based guards (keyword, link limit, duplicate) apply.
 
+### Registering your form for per-form settings
+
+Guard thresholds are global by default. A site can override any of them for one
+form — a contact form is reasonably stricter about links than a comment thread,
+and a long application form needs a longer minimum fill time than a comment box.
+Without overrides the only way to settle a conflict between two forms is to
+loosen the setting for both, weakening protection everywhere to fix one place.
+
+Register the context you pass to `simple_spam_shield_check()` and it gains its
+own section on the **Per-form** settings tab:
+
+```php
+add_filter( 'simple_spam_shield_contexts', function ( array $contexts ) {
+    $contexts['commission_form'] = [ 'label' => 'Commission requests' ];
+    return $contexts;
+} );
+```
+
+Register it when your plugin file loads, so the filter is in place before
+`admin_init` builds the settings screen.
+
+Registration is optional and affects configurability only. **A form that never
+registers is still fully protected** — it just uses the global thresholds, with
+nowhere to override them.
+
+Overridable thresholds: minimum submit time, maximum links, duplicate window,
+rate-limit maximum, rate-limit window, and behavioral threshold. Each resolves
+in this order:
+
+1. the per-form override, if the site set one
+2. the global setting on the Guards tab
+3. the default in `config/guards.json`
+
+A blank override field means inherit, so a site can override one threshold for a
+form without restating the rest.
+
 ### Adding your own guard
 
 Register a class implementing `Guard_Interface` through the

--- a/includes/core/class-admin.php
+++ b/includes/core/class-admin.php
@@ -217,6 +217,35 @@ final class Admin {
 
 		self::add_toggle( 'simple_spam_shield_use_wp_disallowed_keys', __( 'Also apply WordPress\'s Disallowed Comment Keys (Settings → Discussion) to every protected form', 'onsite-spam-guard' ), $guards_page, 'simple_spam_shield_guards', false );
 
+		// ---- Per-form tab ----
+		// One section per registered context. Thresholds stay global; these
+		// only override them, so every field is blank by default and shows the
+		// global value it would otherwise inherit.
+		$contexts_page = $tabs['contexts']['page'];
+
+		add_settings_section(
+			'simple_spam_shield_contexts_intro',
+			__( 'Per-form thresholds', 'onsite-spam-guard' ),
+			function (): void {
+				echo '<p>' . esc_html__( 'Guard thresholds on the Guards tab apply to every form. Where one form needs different values — a contact form is more suspicious of links than a comment thread, and a long application form needs a longer minimum fill time than a comment box — override them here. Leave a field blank to use the global value.', 'onsite-spam-guard' ) . '</p>';
+				echo '<p class="description">' . esc_html__( 'Forms added by other plugins appear here once they register themselves. A form that has not is still protected; it uses the global thresholds.', 'onsite-spam-guard' ) . '</p>';
+			},
+			$contexts_page
+		);
+
+		foreach ( Contexts::all() as $context => $definition ) {
+			$section = 'simple_spam_shield_context_' . $context;
+
+			add_settings_section( $section, $definition['label'], '__return_null', $contexts_page );
+
+			self::add_number_override( 'simple_spam_shield_time_gate_seconds', $context, __( 'Minimum seconds before submit', 'onsite-spam-guard' ), $contexts_page, $section, 3, 1, 30 );
+			self::add_number_override( 'simple_spam_shield_link_limit_max', $context, __( 'Maximum links per submission', 'onsite-spam-guard' ), $contexts_page, $section, 3, 0, 50 );
+			self::add_number_override( 'simple_spam_shield_duplicate_window_seconds', $context, __( 'Duplicate detection window', 'onsite-spam-guard' ), $contexts_page, $section, 60, 1, 86400 );
+			self::add_number_override( 'simple_spam_shield_rate_limit_max', $context, __( 'Rate limit: max submissions', 'onsite-spam-guard' ), $contexts_page, $section, 10, 0, 1000 );
+			self::add_number_override( 'simple_spam_shield_rate_limit_window_seconds', $context, __( 'Rate limit: window length', 'onsite-spam-guard' ), $contexts_page, $section, 60, 1, 86400 );
+			self::add_float_override( 'simple_spam_shield_behavioral_threshold', $context, __( 'Behavioral suspicion threshold', 'onsite-spam-guard' ), $contexts_page, $section, 0.6 );
+		}
+
 		// ---- Allowlist tab ----
 		$allowlist_page = $tabs['allowlist']['page'];
 		add_settings_section( 'simple_spam_shield_allowlist', __( 'Allowlist', 'onsite-spam-guard' ), function () {
@@ -293,6 +322,10 @@ final class Admin {
 			'guards'    => [
 				'label' => __( 'Guards', 'onsite-spam-guard' ),
 				'page'  => 'onsite-spam-guard-guards',
+			],
+			'contexts'  => [
+				'label' => __( 'Per-form', 'onsite-spam-guard' ),
+				'page'  => 'onsite-spam-guard-contexts',
 			],
 			'allowlist' => [
 				'label' => __( 'Allowlist', 'onsite-spam-guard' ),
@@ -498,6 +531,94 @@ final class Admin {
 			if ( $suffix ) {
 				echo ' ' . esc_html( $suffix );
 			}
+		}, $page, $section );
+	}
+
+	/**
+	 * Register an integer override of a global setting, for one context.
+	 *
+	 * Blank means inherit, which is why this cannot reuse add_number(): an
+	 * integer field has no way to express "unset", and storing 0 would be a real
+	 * value rather than an absence. The stored value is a string for that
+	 * reason — '' for inherit, the number otherwise.
+	 */
+	private static function add_number_override( string $option, string $context, string $label, string $page, string $section, int $global_default, int $min, int $max ): void {
+		$name = Contexts::option( $option, $context );
+
+		register_setting( 'onsite-spam-guard', $name, [
+			'type'              => 'string',
+			'sanitize_callback' => static function ( $value ) use ( $min, $max ): string {
+				if ( '' === $value || null === $value ) {
+					return '';
+				}
+
+				return (string) max( $min, min( $max, (int) $value ) );
+			},
+			'default'           => '',
+		] );
+
+		add_settings_field( $name, $label, static function () use ( $name, $option, $global_default, $min, $max ): void {
+			$value  = (string) get_option( $name, '' );
+			$global = get_option( $option, $global_default );
+
+			printf(
+				'<input type="number" name="%1$s" value="%2$s" min="%3$d" max="%4$d" step="1" class="small-text" placeholder="%5$s"> <span class="description">%6$s</span>',
+				esc_attr( $name ),
+				esc_attr( $value ),
+				absint( $min ),
+				absint( $max ),
+				/* translators: placeholder shown in a blank per-form override field. */
+				esc_attr__( 'inherit', 'onsite-spam-guard' ),
+				esc_html(
+					sprintf(
+						/* translators: %s: the global value this form inherits when the field is blank. */
+						__( 'blank = use the global value (%s)', 'onsite-spam-guard' ),
+						(string) $global
+					)
+				)
+			);
+		}, $page, $section );
+	}
+
+	/**
+	 * Register a float override of a global setting, for one context.
+	 *
+	 * Separate from add_number_override() only because the behavioral threshold
+	 * is a 0.0-1.0 score rather than a whole number.
+	 */
+	private static function add_float_override( string $option, string $context, string $label, string $page, string $section, float $global_default ): void {
+		$name = Contexts::option( $option, $context );
+
+		register_setting( 'onsite-spam-guard', $name, [
+			'type'              => 'string',
+			'sanitize_callback' => static function ( $value ): string {
+				if ( '' === $value || null === $value ) {
+					return '';
+				}
+
+				return (string) max( 0.0, min( 1.0, (float) $value ) );
+			},
+			'default'           => '',
+		] );
+
+		add_settings_field( $name, $label, static function () use ( $name, $option, $global_default ): void {
+			$value  = (string) get_option( $name, '' );
+			$global = get_option( $option, $global_default );
+
+			printf(
+				'<input type="number" name="%1$s" value="%2$s" min="0.0" max="1.0" step="0.1" class="small-text" placeholder="%3$s"> <span class="description">%4$s</span>',
+				esc_attr( $name ),
+				esc_attr( $value ),
+				/* translators: placeholder shown in a blank per-form override field. */
+				esc_attr__( 'inherit', 'onsite-spam-guard' ),
+				esc_html(
+					sprintf(
+						/* translators: %s: the global value this form inherits when the field is blank. */
+						__( 'blank = use the global value (%s)', 'onsite-spam-guard' ),
+						(string) $global
+					)
+				)
+			);
 		}, $page, $section );
 	}
 }

--- a/includes/core/class-contexts.php
+++ b/includes/core/class-contexts.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Submission contexts — the forms this plugin protects.
+ *
+ * A context is the label passed to Guard_Runner::run() identifying which form a
+ * submission came from. Three are built in; any other plugin can protect its own
+ * form through simple_spam_shield_check() with a label of its choosing, so the
+ * set is open rather than fixed.
+ *
+ * Registering a context here is what makes it configurable: the settings screen
+ * offers per-context threshold overrides for every context it knows about. An
+ * unregistered context still works and is still protected — it simply uses the
+ * global thresholds, with nowhere to override them.
+ *
+ * @package Simple_Spam_Shield
+ * @since   1.4.0
+ */
+
+declare( strict_types=1 );
+
+namespace Simple_Spam_Shield\Core;
+
+final class Contexts {
+
+	/**
+	 * Every context the settings screen can offer overrides for.
+	 *
+	 * @return array<string, array{label: string}> Context slug => definition.
+	 */
+	public static function all(): array {
+		$contexts = [
+			'comment'      => [ 'label' => __( 'WordPress comments', 'onsite-spam-guard' ) ],
+			'woo_review'   => [ 'label' => __( 'WooCommerce product reviews', 'onsite-spam-guard' ) ],
+			'jetpack_form' => [ 'label' => __( 'Jetpack contact forms', 'onsite-spam-guard' ) ],
+		];
+
+		/**
+		 * Filters the submission contexts offered for per-context configuration.
+		 *
+		 * Register the context your plugin passes to simple_spam_shield_check()
+		 * to give site owners thresholds tuned to your form, rather than the
+		 * one set of values shared by every form on the site:
+		 *
+		 *     add_filter( 'simple_spam_shield_contexts', function ( array $contexts ) {
+		 *         $contexts['commission_form'] = [ 'label' => 'Commission requests' ];
+		 *         return $contexts;
+		 *     } );
+		 *
+		 * Hook this before `admin_init`, since that is when the settings are
+		 * registered. Registering when your plugin file loads is the usual way.
+		 *
+		 * A context that is never registered is still protected — it just falls
+		 * back to the global thresholds.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array<string, array{label: string}> $contexts Context slug => definition.
+		 */
+		/** @var mixed $filtered Whatever the filter returned; it is another plugin's code. */
+		$filtered = apply_filters( 'simple_spam_shield_contexts', $contexts );
+
+		if ( ! is_array( $filtered ) ) {
+			return $contexts;
+		}
+
+		// Drop anything malformed rather than rendering a nameless settings
+		// section, and normalise the key so it is safe as an option-name suffix.
+		$valid = [];
+
+		/** @var mixed $definition */
+		foreach ( $filtered as $slug => $definition ) {
+			$key = self::key( (string) $slug );
+
+			if ( '' === $key || ! is_array( $definition ) || ! isset( $definition['label'] ) ) {
+				continue;
+			}
+
+			$valid[ $key ] = [ 'label' => (string) $definition['label'] ];
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Normalise a context into a form safe to use inside an option name.
+	 *
+	 * @param string $context Raw context label.
+	 */
+	public static function key( string $context ): string {
+		return sanitize_key( $context );
+	}
+
+	/**
+	 * Option name holding a context's override for a global setting.
+	 *
+	 * @param string $option  Global option name.
+	 * @param string $context Submission context.
+	 */
+	public static function option( string $option, string $context ): string {
+		return $option . '__' . self::key( $context );
+	}
+}

--- a/includes/guards/class-abstract-guard.php
+++ b/includes/guards/class-abstract-guard.php
@@ -54,6 +54,38 @@ abstract class Abstract_Guard implements Guard_Interface {
 	}
 
 	/**
+	 * Resolve a threshold for the form the submission came from.
+	 *
+	 * Thresholds are global by default, but a site can override any of them for
+	 * one context — the right link limit genuinely differs between a comment
+	 * thread and a contact form, and without overrides the only way to settle a
+	 * conflict between two forms is to loosen the setting for both.
+	 *
+	 * Resolution order, first hit wins:
+	 *
+	 *   1. the context override, if the site set one
+	 *   2. the global setting
+	 *   3. the default from config/guards.json, then the literal passed in
+	 *
+	 * An override stored as an empty string means "inherit", which is how the
+	 * settings screen represents a field left blank.
+	 *
+	 * @param string $option  Global option name.
+	 * @param string $context Submission context.
+	 * @param mixed  $default Fallback when neither is set.
+	 * @return mixed
+	 */
+	protected function threshold( string $option, string $context, mixed $default ): mixed {
+		$override = get_option( \Simple_Spam_Shield\Core\Contexts::option( $option, $context ), '' );
+
+		if ( '' !== $override && null !== $override && false !== $override ) {
+			return $override;
+		}
+
+		return get_option( $option, $default );
+	}
+
+	/**
 	 * Whether the context is a built-in form whose JS-injected fields (token,
 	 * behavioral data) are guaranteed to be present.
 	 *

--- a/includes/guards/class-behavioral.php
+++ b/includes/guards/class-behavioral.php
@@ -33,8 +33,9 @@ final class Behavioral extends Abstract_Guard {
 
 		$score = $this->calculate_score( $behavioral );
 
-		$threshold = (float) get_option(
+		$threshold = (float) $this->threshold(
 			'simple_spam_shield_behavioral_threshold',
+			$context,
 			$this->config['threshold'] ?? 0.6
 		);
 

--- a/includes/guards/class-duplicate.php
+++ b/includes/guards/class-duplicate.php
@@ -41,7 +41,7 @@ final class Duplicate extends Abstract_Guard {
 		// Floored at 1: set_transient() treats 0 as "no expiration", which would
 		// make this block permanent. The settings field clamps too, but only on
 		// save — this covers a value stored by anything else.
-		$window = max( 1, (int) get_option( 'simple_spam_shield_duplicate_window_seconds', $this->config['window_seconds'] ?? 60 ) );
+		$window = max( 1, (int) $this->threshold( 'simple_spam_shield_duplicate_window_seconds', $context, $this->config['window_seconds'] ?? 60 ) );
 
 		set_transient( self::transient_key( $data ), time(), $window );
 	}

--- a/includes/guards/class-link-limit.php
+++ b/includes/guards/class-link-limit.php
@@ -12,7 +12,7 @@ namespace Simple_Spam_Shield\Guards;
 final class Link_Limit extends Abstract_Guard {
 
 	public function check( array $data, string $context ): \WP_Error|true {
-		$max_links = (int) get_option( 'simple_spam_shield_link_limit_max', $this->config['max_links'] ?? 3 );
+		$max_links = (int) $this->threshold( 'simple_spam_shield_link_limit_max', $context, $this->config['max_links'] ?? 3 );
 		$content   = $data['content'] ?? $data['comment'] ?? '';
 
 		if ( empty( $content ) ) {

--- a/includes/guards/class-rate-limit.php
+++ b/includes/guards/class-rate-limit.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Rate_Limit extends Abstract_Guard {
 
 	public function check( array $data, string $context ): \WP_Error|true {
-		$max = (int) get_option( 'simple_spam_shield_rate_limit_max', $this->config['max_per_window'] ?? 10 );
+		$max = (int) $this->threshold( 'simple_spam_shield_rate_limit_max', $context, $this->config['max_per_window'] ?? 10 );
 
 		// A max of 0 (or less) disables the limit.
 		if ( $max <= 0 ) {
@@ -31,7 +31,7 @@ final class Rate_Limit extends Abstract_Guard {
 		// Floored at 1: set_transient() treats 0 as "no expiration", which would
 		// make this block permanent. The settings field clamps too, but only on
 		// save — this covers a value stored by anything else.
-		$window = max( 1, (int) get_option( 'simple_spam_shield_rate_limit_window_seconds', $this->config['window_seconds'] ?? 60 ) );
+		$window = max( 1, (int) $this->threshold( 'simple_spam_shield_rate_limit_window_seconds', $context, $this->config['window_seconds'] ?? 60 ) );
 
 		// Identify the sender: the logged-in user, else the connection IP.
 		$user_id = get_current_user_id();

--- a/includes/guards/class-time-gate.php
+++ b/includes/guards/class-time-gate.php
@@ -12,7 +12,7 @@ namespace Simple_Spam_Shield\Guards;
 final class Time_Gate extends Abstract_Guard {
 
 	public function check( array $data, string $context ): \WP_Error|true {
-		$min_seconds = (int) get_option( 'simple_spam_shield_time_gate_seconds', $this->config['min_seconds'] ?? 3 );
+		$min_seconds = (int) $this->threshold( 'simple_spam_shield_time_gate_seconds', $context, $this->config['min_seconds'] ?? 3 );
 
 		$token = (string) ( $data['simple_spam_shield_form_loaded'] ?? '' );
 

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-31T17:39:26+00:00\n"
+"POT-Creation-Date: 2026-08-31T18:20:12+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -129,12 +129,12 @@ msgstr ""
 
 #: includes/core/class-admin.php:110
 #: includes/core/class-admin.php:111
-#: includes/core/class-admin.php:402
+#: includes/core/class-admin.php:435
 msgid "Spam Logs"
 msgstr ""
 
 #: includes/core/class-admin.php:130
-#: includes/core/class-admin.php:290
+#: includes/core/class-admin.php:319
 msgid "General"
 msgstr ""
 
@@ -155,10 +155,12 @@ msgid "Choose which form types to protect."
 msgstr ""
 
 #: includes/core/class-admin.php:138
+#: includes/core/class-contexts.php:32
 msgid "WordPress comments"
 msgstr ""
 
 #: includes/core/class-admin.php:139
+#: includes/core/class-contexts.php:33
 msgid "WooCommerce product reviews"
 msgstr ""
 
@@ -175,6 +177,7 @@ msgid "Enable or disable individual spam checks."
 msgstr ""
 
 #: includes/core/class-admin.php:161
+#: includes/core/class-admin.php:241
 msgid "Minimum seconds before submit"
 msgstr ""
 
@@ -184,10 +187,12 @@ msgid "seconds"
 msgstr ""
 
 #: includes/core/class-admin.php:162
+#: includes/core/class-admin.php:242
 msgid "Maximum links per submission"
 msgstr ""
 
 #: includes/core/class-admin.php:163
+#: includes/core/class-admin.php:243
 msgid "Duplicate detection window"
 msgstr ""
 
@@ -196,6 +201,7 @@ msgid "seconds — how long an accepted submission is remembered"
 msgstr ""
 
 #: includes/core/class-admin.php:167
+#: includes/core/class-admin.php:244
 msgid "Rate limit: max submissions"
 msgstr ""
 
@@ -204,10 +210,12 @@ msgid "per sender, per window (0 = no limit)"
 msgstr ""
 
 #: includes/core/class-admin.php:168
+#: includes/core/class-admin.php:245
 msgid "Rate limit: window length"
 msgstr ""
 
 #: includes/core/class-admin.php:181
+#: includes/core/class-admin.php:246
 msgid "Behavioral suspicion threshold"
 msgstr ""
 
@@ -227,96 +235,129 @@ msgstr ""
 msgid "Also apply WordPress's Disallowed Comment Keys (Settings → Discussion) to every protected form"
 msgstr ""
 
-#: includes/core/class-admin.php:222
-#: includes/core/class-admin.php:298
+#: includes/core/class-admin.php:228
+msgid "Per-form thresholds"
+msgstr ""
+
+#: includes/core/class-admin.php:230
+msgid "Guard thresholds on the Guards tab apply to every form. Where one form needs different values — a contact form is more suspicious of links than a comment thread, and a long application form needs a longer minimum fill time than a comment box — override them here. Leave a field blank to use the global value."
+msgstr ""
+
+#: includes/core/class-admin.php:231
+msgid "Forms added by other plugins appear here once they register themselves. A form that has not is still protected; it uses the global thresholds."
+msgstr ""
+
+#: includes/core/class-admin.php:251
+#: includes/core/class-admin.php:331
 msgid "Allowlist"
 msgstr ""
 
-#: includes/core/class-admin.php:223
+#: includes/core/class-admin.php:252
 msgid "Submissions from allowlisted IPs or emails bypass all guards."
 msgstr ""
 
-#: includes/core/class-admin.php:234
+#: includes/core/class-admin.php:263
 msgid "Allowed IPs and emails"
 msgstr ""
 
-#: includes/core/class-admin.php:241
+#: includes/core/class-admin.php:270
 msgid "One entry per line. Supports: exact IPs (192.168.1.1), CIDR ranges (10.0.0.0/8), exact emails (user@example.com), or email domains (@trusted.org)."
 msgstr ""
 
-#: includes/core/class-admin.php:258
+#: includes/core/class-admin.php:287
 msgid "Trust proxy headers for IP detection"
 msgstr ""
 
-#: includes/core/class-admin.php:263
+#: includes/core/class-admin.php:292
 msgid "Use the X-Forwarded-For header to determine the visitor IP."
 msgstr ""
 
-#: includes/core/class-admin.php:264
+#: includes/core/class-admin.php:293
 msgid "Enable only if this site is behind a trusted reverse proxy or load balancer (e.g. Cloudflare, Nginx). When off, the direct connection IP is used. Turning this on without a trusted proxy lets visitors spoof their IP and bypass the allowlist."
 msgstr ""
 
-#: includes/core/class-admin.php:273
 #: includes/core/class-admin.php:302
+#: includes/core/class-admin.php:335
 msgid "Logging"
 msgstr ""
 
-#: includes/core/class-admin.php:274
+#: includes/core/class-admin.php:303
 msgid "Log blocked submissions to database"
 msgstr ""
 
-#: includes/core/class-admin.php:275
+#: includes/core/class-admin.php:304
 msgid "Delete logs older than"
 msgstr ""
 
-#: includes/core/class-admin.php:275
+#: includes/core/class-admin.php:304
 msgid "days (0 = keep forever)"
 msgstr ""
 
-#: includes/core/class-admin.php:276
+#: includes/core/class-admin.php:305
 msgid "Delete all plugin data (spam logs and settings) when this plugin is deleted"
 msgstr ""
 
-#: includes/core/class-admin.php:294
+#: includes/core/class-admin.php:323
 msgid "Guards"
 msgstr ""
 
+#: includes/core/class-admin.php:327
+msgid "Per-form"
+msgstr ""
+
 #. translators: 1: number of blocked submissions, 2: link to logs page
-#: includes/core/class-admin.php:329
+#: includes/core/class-admin.php:362
 #, php-format
 msgid "%1$d submissions blocked. %2$s"
 msgstr ""
 
-#: includes/core/class-admin.php:332
+#: includes/core/class-admin.php:365
 msgid "View spam logs →"
 msgstr ""
 
-#: includes/core/class-admin.php:407
+#: includes/core/class-admin.php:440
 msgid "All spam logs cleared."
 msgstr ""
 
-#: includes/core/class-admin.php:417
+#: includes/core/class-admin.php:450
 msgid "Delete all log entries?"
 msgstr ""
 
-#: includes/core/class-admin.php:418
+#: includes/core/class-admin.php:451
 msgid "Clear all logs"
 msgstr ""
 
 #. translators: %d: number of submissions blocked in the last 7 days.
-#: includes/core/class-admin.php:427
+#: includes/core/class-admin.php:460
 #, php-format
 msgid "Blocked in the last 7 days: %d."
 msgstr ""
 
 #. translators: 1: guard name, 2: number of blocks by that guard.
-#: includes/core/class-admin.php:434
+#: includes/core/class-admin.php:467
 #, php-format
 msgid "Most active guard: %1$s (%2$d)."
 msgstr ""
 
+#. translators: placeholder shown in a blank per-form override field.
+#: includes/core/class-admin.php:571
+#: includes/core/class-admin.php:613
+msgid "inherit"
+msgstr ""
+
+#. translators: %s: the global value this form inherits when the field is blank.
+#: includes/core/class-admin.php:575
+#: includes/core/class-admin.php:617
+#, php-format
+msgid "blank = use the global value (%s)"
+msgstr ""
+
 #: includes/core/class-assets.php:85
 msgid "Website"
+msgstr ""
+
+#: includes/core/class-contexts.php:34
+msgid "Jetpack contact forms"
 msgstr ""
 
 #. translators: 1: guard slug, 2: class name, 3: interface name.
@@ -325,7 +366,7 @@ msgstr ""
 msgid "Guard \"%1$s\" was skipped: %2$s does not implement %3$s."
 msgstr ""
 
-#: includes/guards/class-behavioral.php:43
+#: includes/guards/class-behavioral.php:44
 msgid "Submission rejected — suspicious activity detected."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,8 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 == Changelog ==
 
 = 1.4.0 =
+* New **Per-form** settings tab. Guard thresholds used to apply identically to every form on the site, so making a contact form stricter also made the comment form stricter. Thresholds can now be set per form — a comment thread can allow several links while a contact form allows one, and a long application form can require a longer fill time than a comment box. Leave a field blank to use the global value.
+* Plugins that protect their own forms through this plugin can register them so they appear on the Per-form tab. A form that does not register is still protected; it uses the global thresholds.
 * The duplicate-detection window and the rate-limit window are now settable on the Guards tab. Both were fixed at 60 seconds and could only be changed by editing a file inside the plugin, which an update overwrote. A rate limit of "20 per hour" is now expressible, and a busy comment thread where several people legitimately post a short reply within a minute can use a shorter duplicate window instead of turning the guard off.
 * The rate-limit maximum is no longer labelled "per minute", since the window is no longer always a minute.
 * Number settings are now range-checked when saved. Previously a value outside a field's range was stored as given, and a negative number was stored as its positive equivalent.

--- a/tests/PerContextConfigTest.php
+++ b/tests/PerContextConfigTest.php
@@ -1,0 +1,177 @@
+<?php
+declare( strict_types=1 );
+
+use PHPUnit\Framework\TestCase;
+use Simple_Spam_Shield\Core\Contexts;
+use Simple_Spam_Shield\Core\Config;
+use Simple_Spam_Shield\Core\Guard_Runner;
+use Simple_Spam_Shield\Guards\Link_Limit;
+use Simple_Spam_Shield\Guards\Time_Gate;
+use Simple_Spam_Shield\Guards\Duplicate;
+
+/** Per-context threshold overrides (#21). */
+final class PerContextConfigTest extends TestCase {
+
+	protected function setUp(): void {
+		Config::init( SIMPLE_SPAM_SHIELD_PLUGIN_ROOT . '/config/' );
+		$GLOBALS['simple_spam_shield_test_options']               = [];
+		$GLOBALS['simple_spam_shield_test_transients']            = [];
+		$GLOBALS['simple_spam_shield_test_transient_expirations'] = [];
+		$GLOBALS['simple_spam_shield_test_filters']               = [];
+		$_SERVER['REMOTE_ADDR']                                   = '198.51.100.7';
+	}
+
+	private function linkLimit(): Link_Limit {
+		return new Link_Limit( 'link_limit', [ 'max_links' => 3 ] );
+	}
+
+	private function twoLinks(): array {
+		return [ 'content' => 'see http://a.example and http://b.example' ];
+	}
+
+	// --- the registry ------------------------------------------------------
+
+	public function test_the_three_built_in_contexts_are_registered(): void {
+		$this->assertSame(
+			[ 'comment', 'woo_review', 'jetpack_form' ],
+			array_keys( Contexts::all() )
+		);
+	}
+
+	public function test_a_plugin_can_register_its_own_context(): void {
+		add_filter( 'simple_spam_shield_contexts', static function ( array $c ): array {
+			$c['commission_form'] = [ 'label' => 'Commission requests' ];
+			return $c;
+		} );
+
+		$this->assertArrayHasKey( 'commission_form', Contexts::all() );
+	}
+
+	public function test_a_malformed_registration_is_dropped_rather_than_rendered_nameless(): void {
+		add_filter( 'simple_spam_shield_contexts', static function ( array $c ): array {
+			$c['no_label'] = [ 'weight' => 5 ];   // missing label
+			$c['not_even_an_array'] = 'nope';
+			return $c;
+		} );
+
+		$all = Contexts::all();
+		$this->assertArrayNotHasKey( 'no_label', $all );
+		$this->assertArrayNotHasKey( 'not_even_an_array', $all );
+		$this->assertArrayHasKey( 'comment', $all, 'valid contexts must survive' );
+	}
+
+	public function test_a_filter_returning_a_non_array_falls_back_to_the_builtins(): void {
+		add_filter( 'simple_spam_shield_contexts', static fn() => 'not an array' );
+
+		$this->assertCount( 3, Contexts::all() );
+	}
+
+	public function test_context_keys_are_normalised_for_use_in_an_option_name(): void {
+		// sanitize_key() lowercases and strips anything outside [a-z0-9_-] —
+		// it removes the space rather than replacing it.
+		$this->assertSame( 'myform', Contexts::key( 'My Form' ) );
+		$this->assertSame( 'rsvp_form', Contexts::key( 'RSVP_Form' ) );
+		$this->assertSame(
+			'simple_spam_shield_link_limit_max__rsvp_form',
+			Contexts::option( 'simple_spam_shield_link_limit_max', 'rsvp_form' )
+		);
+	}
+
+	/** The runner's context and the settings key must agree, or an override silently never applies. */
+	public function test_a_context_registered_unnormalised_still_matches_at_runtime(): void {
+		add_filter( 'simple_spam_shield_contexts', static function ( array $c ): array {
+			$c['Commission Form'] = [ 'label' => 'Commission requests' ];
+			return $c;
+		} );
+
+		$registered = array_keys( Contexts::all() );
+		$this->assertContains( 'commissionform', $registered );
+
+		// A guard handed the raw label resolves to the same option name.
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max']                 = 3;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max__commissionform'] = '1';
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$this->linkLimit()->check( $this->twoLinks(), 'Commission Form' )
+		);
+	}
+
+	// --- resolution --------------------------------------------------------
+
+	public function test_a_context_override_beats_the_global(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max']                   = 3;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max__commission_form']  = '1';
+
+		$this->assertTrue( $this->linkLimit()->check( $this->twoLinks(), 'comment' ) );
+		$this->assertInstanceOf( WP_Error::class, $this->linkLimit()->check( $this->twoLinks(), 'commission_form' ) );
+	}
+
+	public function test_a_blank_override_inherits_the_global_rather_than_meaning_zero(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max']                  = 3;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max__commission_form'] = '';
+
+		$this->assertTrue(
+			$this->linkLimit()->check( $this->twoLinks(), 'commission_form' ),
+			'blank must inherit 3, not collapse to 0 and block everything'
+		);
+	}
+
+	public function test_zero_is_a_real_override_and_not_treated_as_blank(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max']                  = 3;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max__commission_form'] = '0';
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$this->linkLimit()->check( [ 'content' => 'one http://a.example link' ], 'commission_form' ),
+			'0 links must be enforceable as a deliberate setting'
+		);
+	}
+
+	public function test_an_unregistered_context_falls_back_to_the_global(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_link_limit_max'] = 1;
+
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$this->linkLimit()->check( $this->twoLinks(), 'never_registered_anywhere' )
+		);
+	}
+
+	public function test_the_config_default_still_applies_when_nothing_is_set(): void {
+		// guards.json says 3, so two links pass and four do not.
+		$this->assertTrue( $this->linkLimit()->check( $this->twoLinks(), 'comment' ) );
+		$this->assertInstanceOf(
+			WP_Error::class,
+			$this->linkLimit()->check(
+				[ 'content' => 'a http://a.example b http://b.example c http://c.example d http://d.example' ],
+				'comment'
+			)
+		);
+	}
+
+	// --- the same, on other guards ----------------------------------------
+
+	public function test_time_gate_honours_a_per_context_override(): void {
+		$secret = str_repeat( 'k', 64 );
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_token_secret']              = $secret;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_time_gate_seconds']         = 3;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_time_gate_seconds__survey'] = '30';
+
+		$issued = time() - 10;   // ten seconds: fine globally, too fast for the survey
+		$data   = [ 'simple_spam_shield_form_loaded' => $issued . '.' . hash_hmac( 'sha256', (string) $issued, $secret ) ];
+		$guard  = new Time_Gate( 'time_gate', [ 'min_seconds' => 3 ] );
+
+		$this->assertTrue( $guard->check( $data, 'comment' ) );
+		$this->assertInstanceOf( WP_Error::class, $guard->check( $data, 'survey' ) );
+	}
+
+	public function test_duplicate_window_override_reaches_the_transient(): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_duplicate_window_seconds']          = 60;
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_duplicate_window_seconds__comment'] = '5';
+
+		$guard = new Duplicate( 'duplicate', [ 'window_seconds' => 60 ] );
+		$guard->commit( [ 'content' => 'Thanks!' ], 'comment' );
+
+		$this->assertSame( [ 5 ], array_values( $GLOBALS['simple_spam_shield_test_transient_expirations'] ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,13 @@ if ( ! function_exists( 'add_option' ) ) {
 // --- In-memory transient store ---------------------------------------------
 $GLOBALS['simple_spam_shield_test_transients'] = [];
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	// Mirrors wp-includes/formatting.php: lowercase, then strip anything
+	// outside [a-z0-9_-].
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
 if ( ! function_exists( 'get_transient' ) ) {
 	function get_transient( $key ) {
 		return $GLOBALS['simple_spam_shield_test_transients'][ $key ] ?? false;

--- a/uninstall.php
+++ b/uninstall.php
@@ -66,7 +66,19 @@ function simple_spam_shield_uninstall_site(): void {
 		delete_option( $option );
 	}
 
-	// 3. Clean up every transient the plugin creates. Matching on the shared
+	// 3. Delete per-context threshold overrides. These cannot be listed
+	// individually: there is one per setting per context, and contexts are
+	// registered by other plugins at runtime, so the set is not knowable here.
+	// Matching the `<option>__<context>` suffix covers every one.
+	//
+	// Underscores are escaped because `_` is a single-character wildcard in
+	// SQL LIKE, so an unescaped pattern matches more loosely than it looks.
+	$wpdb->query(
+		"DELETE FROM {$wpdb->options}
+		  WHERE option_name LIKE 'simple\_spam\_shield\_%\_\_%'"
+	); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+	// 4. Clean up every transient the plugin creates. Matching on the shared
 	// prefix covers duplicate detection, rate limiting, and anything added
 	// later, rather than naming each family and forgetting one — the
 	// rate-limit transients added in 1.2.0 were missed by the old pattern.
@@ -79,10 +91,10 @@ function simple_spam_shield_uninstall_site(): void {
 		     OR option_name LIKE '\\_transient\\_timeout\\_simple\\_spam\\_shield\\_%'"
 	); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 
-	// 4. Delete the stats transient.
+	// 5. Delete the stats transient.
 	delete_transient( 'simple_spam_shield_stats' );
 
-	// 5. Clear the scheduled retention-purge cron event.
+	// 6. Clear the scheduled retention-purge cron event.
 	wp_clear_scheduled_hook( 'simple_spam_shield_purge_logs' );
 }
 


### PR DESCRIPTION
Closes #21. Second of the 1.4.0 milestone, building on the global window settings from #19.

## The problem

Every guard threshold was global, applied identically to comments, WooCommerce reviews, Jetpack forms and anything integrated through the API. The only way to resolve a conflict between two forms was to loosen the setting for both — weakening protection everywhere to fix one place.

Six thresholds are now overridable per form: minimum submit time, maximum links, duplicate window, rate-limit maximum, rate-limit window, and behavioral threshold. Honeypot and Nonce have no thresholds and are unaffected.

## Contexts are an open set

`simple_spam_shield_check()` takes any label, so the settings screen cannot enumerate contexts by inspection. New `Core\Contexts` registry: the three built-ins register themselves, and a `simple_spam_shield_contexts` filter lets an integrator add its own with a human label — composing with the guard-registration filter from #6.

```php
add_filter( 'simple_spam_shield_contexts', function ( array $contexts ) {
    $contexts['commission_form'] = [ 'label' => 'Commission requests' ];
    return $contexts;
} );
```

**Registration affects configurability only.** A form that never registers is still fully protected; it just uses the globals, with nowhere to override them.

## Resolution

Added as `Abstract_Guard::threshold()`, so each guard changed by one line:

1. the per-form override, if set
2. the global setting
3. `config/guards.json`, then the literal

**Blank means inherit**, so one threshold can be overridden without restating the rest. That distinction is load-bearing: an override stored as `''` must fall back to the global, while a stored `0` is a real value — 0 links is a deliberate setting, and treating blank as 0 would silently block every submission containing a link. Overrides are stored as strings for exactly that reason, since an integer field cannot express "unset".

The regression test fails against the naive version that treats any stored value as authoritative:

```
blank must inherit 3, not collapse to 0 and block everything
FAILURES! Tests: 1, Assertions: 1, Failures: 1.
```

## Verified live

```
registered contexts:  comment, woo_review, jetpack_form, commission_form

global link limit 3, commission_form overridden to 1
  2 links in comment          -> allowed
  2 links in commission_form  -> BLOCKED
  blank override              -> allowed (inheriting 3)
```

The Per-form tab registers 3 sections × 6 fields, and sanitisation clamps to each field's range while preserving blank:

```
''    -> ''      (inherit)
'7'   -> '7'
'0'   -> '0'     (a real value, not blank)
'-4'  -> '0'
'999' -> '50'
behavioral '5' -> '1',  '-1' -> '0'
```

## Uninstall

These cannot be listed individually — one per setting per context, with contexts registered at runtime. Uninstall matches the `<option>__<context>` suffix instead, with underscores escaped because `_` is a single-character wildcard in SQL LIKE. Verified against seeded rows:

```
matched:   simple_spam_shield_link_limit_max__comment
           simple_spam_shield_behavioral_threshold__rsvp_form
untouched: simple_spam_shield_link_limit_max      (global, listed separately)
           some_other_plugin__setting             (another plugin)
           simple_spam_shieldXlink__x             (wildcard-escaping probe)
```

## Notes

- The test harness gains a `sanitize_key()` stub mirroring core's. One test asserts a context registered unnormalised (`'Commission Form'`) still matches at runtime, since a mismatch there would mean an override that silently never applies.
- `Contexts::all()` refuses a malformed registration (missing label, non-array) rather than rendering a nameless settings section, and falls back to the built-ins if the filter returns a non-array — same defensive shape as `Guard_Runner::definitions()`.

## Gate

| Check | Result |
| --- | --- |
| PHPUnit | 128 tests, 222 assertions (13 new) |
| PHPStan level 5 | no errors |
| PHPCS (WPCS) | clean |
| `bin/check-pot.sh` | up to date, 90 strings |
| Plugin Check (built package) | no errors |

Version stays 1.3.0 with notes under `[Unreleased]`; 1.4.0 ships once #23 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
