### PR TITLE
Derive the honeypot field name per site (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,26 @@ The user-facing changelog shipped to WordPress.org lives in the
 
 ## [Unreleased]
 
-## [Unreleased]
+## [1.4.0] - 2026-08-31
+
+### Security
+- The honeypot field name is now derived per site from the signing secret
+  (`ossg_<12 hex>`) instead of being `simple_spam_shield_website_url` on every
+  install. A fixed name made the highest-weight guard a permanent, skip-listable
+  target: a bot author who encountered the plugin once could defeat the honeypot
+  on every site running it. The name is stable for a site, so cached pages and
+  forms already open in a browser keep working.
+
+  The legacy name is still accepted on submission, which matters more than it
+  looks: a page cached before this release serves a form carrying the old name,
+  and without the fallback that submission would arrive with no honeypot value
+  and pass rather than block — failing open, silently, for as long as the cache
+  lives. The reader takes the first *non-empty* value of the two, so an empty
+  new field cannot mask a bot that filled the old one.
+
+  Only the rendered name changed. The `$fields` key accepted by
+  `simple_spam_shield_check()` remains `simple_spam_shield_website_url`, so no
+  integration needs updating.
 
 ### Added
 - Per-form threshold overrides. Every guard threshold was global — one link

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ uninstall.php            → Clean deletion of all plugin data
 
 | Guard | Weight | Default | Description |
 |---|---|---|---|
-| **Honeypot** | 100 | On | Hidden field that bots fill in but humans never see |
+| **Honeypot** | 100 | On | Hidden field that bots fill in but humans never see. The field name is derived from the site's signing secret, so it differs per install rather than being a fixed target a bot author can skip-list once |
 | **Duplicate detection** | 95 | On | Rejects identical submissions within a 60-second window using transient-based hashing |
 | **Time gate** | 90 | On | Rejects submissions completed faster than a human could type (configurable, default 3s), using a server-signed issue time |
 | **Rate limit** | 85 | Off | Throttles repeated submissions from the same sender within a rolling window; keyed on the logged-in user ID when present, the connection IP otherwise |
@@ -103,6 +103,8 @@ When the plugin is deleted (not just deactivated), `uninstall.php` drops the cus
 Other plugins can run their own form submissions through Onsite Spam Guard's guards via a small, stable public API (`includes/api.php`). Integrate through these prefixed functions — not the internal classes — and wrap calls in `function_exists()` so your plugin degrades gracefully when Onsite Spam Guard is inactive.
 
 **1. Check a submission (server side).** Pass the human-meaningful fields; the hidden honeypot/token/behavioral fields are read from `$_POST` automatically. Returns `true` or a `WP_Error`.
+
+The honeypot's rendered field name is per-site, so read it from `Honeypot::field_name()` rather than hardcoding it — or simply let `simple_spam_shield_field_markup()` render the field for you, which is the usual path. The `$fields` key in the call below stays `simple_spam_shield_website_url` regardless; that is a stable contract, unrelated to the name on the wire.
 
 ```php
 if ( function_exists( 'simple_spam_shield_check' ) ) {

--- a/assets/js/guard.js
+++ b/assets/js/guard.js
@@ -20,7 +20,11 @@
 
 	// Forms rendered by simple_spam_shield_field_markup() already carry this
 	// honeypot field; we enhance them too (behavioral handler, missing fields).
-	var HONEYPOT_NAME = 'simple_spam_shield_website_url';
+	// Per-site name (#23), supplied by the server. The literal is the fallback
+	// for a cached copy of this script served before the payload gained the
+	// field; the server accepts that name too.
+	var LEGACY_HONEYPOT_NAME = 'simple_spam_shield_website_url';
+	var HONEYPOT_NAME = simpleSpamShieldGuard.honeypot || LEGACY_HONEYPOT_NAME;
 
 	// --- Behavioral analysis tracking ---
 	// Ported from Comment & Form Guard.
@@ -74,13 +78,16 @@
 
 		// Honeypot field — looks like a legitimate "website" field to bots.
 		// Skipped when the form already carries one (server-rendered markup).
-		if ( ! hasField( form, HONEYPOT_NAME ) ) {
+		// The legacy name counts as carrying one: a page cached before the
+		// per-site name (#23) still holds that field, and adding a second
+		// honeypot beside it would leave two "website" inputs in one form.
+		if ( ! hasField( form, HONEYPOT_NAME ) && ! hasField( form, LEGACY_HONEYPOT_NAME ) ) {
 			var hp = document.createElement( 'div' );
 			hp.className = 'onsite-spam-guard-hp-wrap';
 			hp.setAttribute( 'aria-hidden', 'true' );
 			hp.innerHTML =
-				'<label for="simple_spam_shield_website_url">Website</label>' +
-				'<input type="text" name="simple_spam_shield_website_url" id="simple_spam_shield_website_url" value="" tabindex="-1" autocomplete="off">';
+				'<label for="' + HONEYPOT_NAME + '">Website</label>' +
+				'<input type="text" name="' + HONEYPOT_NAME + '" id="' + HONEYPOT_NAME + '" value="" tabindex="-1" autocomplete="off">';
 			form.appendChild( hp );
 		}
 
@@ -110,7 +117,9 @@
 			document.querySelectorAll( selector ).forEach( injectFields );
 		} );
 
-		document.querySelectorAll( 'input[name="' + HONEYPOT_NAME + '"]' ).forEach( function ( input ) {
+		document.querySelectorAll(
+			'input[name="' + HONEYPOT_NAME + '"], input[name="' + LEGACY_HONEYPOT_NAME + '"]'
+		).forEach( function ( input ) {
 			var form = input.closest( 'form' );
 			if ( form ) {
 				injectFields( form );

--- a/includes/api.php
+++ b/includes/api.php
@@ -55,9 +55,12 @@ if ( ! function_exists( 'simple_spam_shield_check' ) ) {
 		// empty for a JSON body), falling back to the form-POST superglobal.
 		// Each branch sanitizes at the point of access.
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Anti-spam check on a third-party submission; values are sanitized on read.
+		// The documented $fields key stays 'simple_spam_shield_website_url' — it
+		// is a public contract and unrelated to the per-site name rendered in
+		// markup (#23). Only the $_POST fallback needs to accept either name.
 		$website    = isset( $fields['simple_spam_shield_website_url'] )
 			? sanitize_text_field( (string) $fields['simple_spam_shield_website_url'] )
-			: sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_website_url'] ?? '' ) );
+			: \Simple_Spam_Shield\Guards\Honeypot::value_from_request( $_POST );
 		$token      = isset( $fields['simple_spam_shield_form_loaded'] )
 			? sanitize_text_field( (string) $fields['simple_spam_shield_form_loaded'] )
 			: sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_form_loaded'] ?? '' ) );

--- a/includes/core/class-assets.php
+++ b/includes/core/class-assets.php
@@ -40,6 +40,7 @@ final class Assets {
 		wp_localize_script( 'onsite-spam-guard-frontend', 'simpleSpamShieldGuard', [
 			'token'     => Token::issue(),
 			'selectors' => self::selectors(),
+			'honeypot'  => \Simple_Spam_Shield\Guards\Honeypot::field_name(),
 		] );
 	}
 
@@ -80,8 +81,13 @@ final class Assets {
 	 * @return string
 	 */
 	public static function field_markup(): string {
+		// Per-site field name (#23), so the honeypot is not a fixed target a bot
+		// author can skip-list once and defeat everywhere.
+		$field = \Simple_Spam_Shield\Guards\Honeypot::field_name();
+
 		$honeypot = sprintf(
-			'<div class="onsite-spam-guard-hp-wrap" aria-hidden="true"><label for="simple_spam_shield_website_url">%s</label><input type="text" name="simple_spam_shield_website_url" id="simple_spam_shield_website_url" value="" tabindex="-1" autocomplete="off"></div>',
+			'<div class="onsite-spam-guard-hp-wrap" aria-hidden="true"><label for="%1$s">%2$s</label><input type="text" name="%1$s" id="%1$s" value="" tabindex="-1" autocomplete="off"></div>',
+			esc_attr( $field ),
 			esc_html__( 'Website', 'onsite-spam-guard' )
 		);
 

--- a/includes/core/class-token.php
+++ b/includes/core/class-token.php
@@ -66,6 +66,21 @@ final class Token {
 	/**
 	 * Get the per-site signing secret, generating and storing it on first use.
 	 */
+	/**
+	 * Derive a stable, site-specific value from the signing secret.
+	 *
+	 * Stable for a site, so cached pages and in-flight forms keep working, and
+	 * unpredictable across sites, so a value derived here cannot be guessed
+	 * from the outside. Used for the honeypot field name, which would otherwise
+	 * be identical on every install and therefore trivially skip-listed.
+	 *
+	 * @param string $purpose Distinguishes derived values from one another.
+	 * @param int    $length  Hex characters to return.
+	 */
+	public static function derive( string $purpose, int $length = 12 ): string {
+		return substr( hash_hmac( 'sha256', $purpose, self::secret() ), 0, max( 1, $length ) );
+	}
+
 	private static function secret(): string {
 		$secret = get_option( self::SECRET_OPTION );
 

--- a/includes/guards/class-honeypot.php
+++ b/includes/guards/class-honeypot.php
@@ -12,15 +12,60 @@ namespace Simple_Spam_Shield\Guards;
 final class Honeypot extends Abstract_Guard {
 
 	/**
-	 * The hidden field's name.
+	 * Key this guard reads from the normalised submission data.
 	 *
-	 * Intentionally a constant rather than configuration: the name is also
-	 * hardcoded in the rendered markup, the front-end script and every
-	 * integration that forwards it, so a configurable value that only this
-	 * class honoured would silently disable the guard. See #23 for wiring it
-	 * through properly, which would allow a per-site randomised name.
+	 * This is internal plumbing, not the name rendered in the form — that is
+	 * per-site and comes from field_name(). Integrations read whichever field
+	 * name arrived and normalise it to this key, so the guard, the public
+	 * simple_spam_shield_check() contract and every test stay stable while the
+	 * name on the wire varies by site.
+	 *
+	 * It doubles as the legacy wire name, which is still accepted; see
+	 * value_from_request().
 	 */
 	public const FIELD = 'simple_spam_shield_website_url';
+
+	/**
+	 * The field name rendered into forms on this site.
+	 *
+	 * Every install used to render `simple_spam_shield_website_url`, making the
+	 * highest-weight guard a fixed target: a bot author who met the plugin once
+	 * could add that name to a skip-list and defeat it on every site running
+	 * it, permanently. Deriving the name from the site's signing secret keeps it
+	 * stable for a site — so cached pages and forms already in a visitor's
+	 * browser keep working — while differing between sites and being
+	 * unpredictable from the outside.
+	 */
+	public static function field_name(): string {
+		return 'ossg_' . \Simple_Spam_Shield\Core\Token::derive( 'honeypot-field' );
+	}
+
+	/**
+	 * Read the honeypot value out of a request array.
+	 *
+	 * Accepts the per-site name and the legacy one. The legacy fallback is not
+	 * merely for old integrations: a page cached before this release serves a
+	 * form carrying the old name, and without it that submission would arrive
+	 * with no honeypot value at all. The guard would then pass rather than
+	 * block — failing open, and silently, for as long as the cache lives.
+	 *
+	 * Returns the first *non-empty* value rather than the first key present.
+	 * Both names can legitimately arrive at once — a page cached before this
+	 * release carries the old field while the current script injects the new
+	 * one — and returning the empty one would let a bot that filled only the
+	 * other sail through.
+	 *
+	 * @param array $source Request data, typically $_POST.
+	 */
+	public static function value_from_request( array $source ): string {
+		foreach ( [ self::field_name(), self::FIELD ] as $key ) {
+			if ( ! empty( $source[ $key ] ) ) {
+				return sanitize_text_field( wp_unslash( $source[ $key ] ) );
+			}
+		}
+
+		return '';
+	}
 
 	public function check( array $data, string $context ): \WP_Error|true {
 		// If the honeypot field is present and non-empty, it's a bot.

--- a/includes/integrations/class-comments.php
+++ b/includes/integrations/class-comments.php
@@ -99,7 +99,7 @@ final class Comments {
 			// plugin nonce to verify at this stage (that is the optional Nonce
 			// guard's job downstream). Values are sanitized on read.
 			// phpcs:disable WordPress.Security.NonceVerification.Missing
-			'simple_spam_shield_website_url'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_website_url'] ?? '' ) ),
+			'simple_spam_shield_website_url'     => \Simple_Spam_Shield\Guards\Honeypot::value_from_request( $_POST ),
 			'simple_spam_shield_form_loaded'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_form_loaded'] ?? '' ) ),
 			'simple_spam_shield_behavioral_data' => sanitize_textarea_field( wp_unslash( $_POST['simple_spam_shield_behavioral_data'] ?? '' ) ),
 			// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/includes/integrations/class-jetpack-forms.php
+++ b/includes/integrations/class-jetpack-forms.php
@@ -96,7 +96,7 @@ final class Jetpack_Forms {
 			// plugin nonce to verify at this stage (that is the optional Nonce
 			// guard's job downstream). Values are sanitized on read.
 			// phpcs:disable WordPress.Security.NonceVerification.Missing
-			'simple_spam_shield_website_url'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_website_url'] ?? '' ) ),
+			'simple_spam_shield_website_url'     => \Simple_Spam_Shield\Guards\Honeypot::value_from_request( $_POST ),
 			'simple_spam_shield_form_loaded'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_form_loaded'] ?? '' ) ),
 			'simple_spam_shield_behavioral_data' => sanitize_textarea_field( wp_unslash( $_POST['simple_spam_shield_behavioral_data'] ?? '' ) ),
 			// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -76,7 +76,7 @@ final class WooCommerce {
 			// plugin nonce to verify at this stage (that is the optional Nonce
 			// guard's job downstream). Values are sanitized on read.
 			// phpcs:disable WordPress.Security.NonceVerification.Missing
-			'simple_spam_shield_website_url'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_website_url'] ?? '' ) ),
+			'simple_spam_shield_website_url'     => \Simple_Spam_Shield\Guards\Honeypot::value_from_request( $_POST ),
 			'simple_spam_shield_form_loaded'     => sanitize_text_field( wp_unslash( $_POST['simple_spam_shield_form_loaded'] ?? '' ) ),
 			'simple_spam_shield_behavioral_data' => sanitize_textarea_field( wp_unslash( $_POST['simple_spam_shield_behavioral_data'] ?? '' ) ),
 			// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/languages/onsite-spam-guard.pot
+++ b/languages/onsite-spam-guard.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Onsite Spam Guard 1.3.0\n"
+"Project-Id-Version: Onsite Spam Guard 1.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/onsite-spam-guard\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-31T18:20:12+00:00\n"
+"POT-Creation-Date: 2026-08-31T18:48:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: onsite-spam-guard\n"
@@ -352,7 +352,7 @@ msgstr ""
 msgid "blank = use the global value (%s)"
 msgstr ""
 
-#: includes/core/class-assets.php:85
+#: includes/core/class-assets.php:91
 msgid "Website"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "Duplicate submission detected — please wait before resubmitting."
 msgstr ""
 
-#: includes/guards/class-honeypot.php:29
+#: includes/guards/class-honeypot.php:74
 msgid "Submission rejected."
 msgstr ""
 

--- a/onsite-spam-guard.php
+++ b/onsite-spam-guard.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Onsite Spam Guard
  * Description: Config-driven spam prevention for Comments, WooCommerce Reviews, and Jetpack Contact Form blocks — no external services required.
- * Version:     1.3.0
+ * Version:     1.4.0
  * Requires at least: 6.2
  * Requires PHP: 8.2
  * Author:      Jerome Wincek
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.3.0' );
+define( 'SIMPLE_SPAM_SHIELD_VERSION', '1.4.0' );
 define( 'SIMPLE_SPAM_SHIELD_FILE', __FILE__ );
 define( 'SIMPLE_SPAM_SHIELD_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SIMPLE_SPAM_SHIELD_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: spam, antispam, comments, honeypot, woocommerce
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.3.0
+Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,7 @@ By default, yes — deleting the plugin (not just deactivating it) drops its dat
 == Changelog ==
 
 = 1.4.0 =
+* The hidden honeypot field now has a different name on every site, derived from the site's own secret. Previously every installation used the same name, so a spammer who learned it once could skip that field on every site running this plugin. Nothing to configure, and forms already open in a visitor's browser keep working.
 * New **Per-form** settings tab. Guard thresholds used to apply identically to every form on the site, so making a contact form stricter also made the comment form stricter. Thresholds can now be set per form — a comment thread can allow several links while a contact form allows one, and a long application form can require a longer fill time than a comment box. Leave a field blank to use the global value.
 * Plugins that protect their own forms through this plugin can register them so they appear on the Per-form tab. A form that does not register is still protected; it uses the global thresholds.
 * The duplicate-detection window and the rate-limit window are now settable on the Guards tab. Both were fixed at 60 seconds and could only be changed by editing a file inside the plugin, which an update overwrote. A rate limit of "20 per hour" is now expressible, and a busy comment thread where several people legitimately post a short reply within a minute can use a shorter duplicate window instead of turning the guard off.

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -67,7 +67,16 @@ final class ApiTest extends TestCase {
 
 	public function test_field_markup_contains_all_hidden_fields(): void {
 		$markup = simple_spam_shield_field_markup();
-		$this->assertStringContainsString( 'name="simple_spam_shield_website_url"', $markup );
+		// The honeypot name is per-site (#23), so assert the derived one.
+		$this->assertStringContainsString(
+			'name="' . \Simple_Spam_Shield\Guards\Honeypot::field_name() . '"',
+			$markup
+		);
+		$this->assertStringNotContainsString(
+			'name="simple_spam_shield_website_url"',
+			$markup,
+			'the fixed legacy name must no longer be rendered'
+		);
 		$this->assertStringContainsString( 'name="simple_spam_shield_form_loaded"', $markup );
 		$this->assertStringContainsString( 'name="simple_spam_shield_behavioral_data"', $markup );
 	}

--- a/tests/HoneypotFieldNameTest.php
+++ b/tests/HoneypotFieldNameTest.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types=1 );
+
+use PHPUnit\Framework\TestCase;
+use Simple_Spam_Shield\Core\Assets;
+use Simple_Spam_Shield\Core\Config;
+use Simple_Spam_Shield\Core\Guard_Runner;
+use Simple_Spam_Shield\Guards\Honeypot;
+
+/** Per-site honeypot field name (#23). */
+final class HoneypotFieldNameTest extends TestCase {
+
+	private const SECRET_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+	private const SECRET_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+	public static function setUpBeforeClass(): void {
+		Config::init( SIMPLE_SPAM_SHIELD_PLUGIN_ROOT . '/config/' );
+		Guard_Runner::init();
+	}
+
+	protected function setUp(): void {
+		$GLOBALS['simple_spam_shield_test_options']    = [
+			'simple_spam_shield_enabled'      => true,
+			'simple_spam_shield_log_blocked'  => false,
+			'simple_spam_shield_token_secret' => self::SECRET_A,
+		];
+		$GLOBALS['simple_spam_shield_test_transients'] = [];
+		$GLOBALS['simple_spam_shield_test_filters']    = [];
+		$_SERVER['REMOTE_ADDR']                        = '198.51.100.23';
+		$_POST                                         = [];
+	}
+
+	private function useSecret( string $secret ): void {
+		$GLOBALS['simple_spam_shield_test_options']['simple_spam_shield_token_secret'] = $secret;
+	}
+
+	// --- derivation --------------------------------------------------------
+
+	public function test_the_name_is_stable_for_a_site(): void {
+		// Must not change between requests, or a form already in a visitor's
+		// browser (or on a cached page) would submit a name the server ignores.
+		$this->assertSame( Honeypot::field_name(), Honeypot::field_name() );
+	}
+
+	public function test_the_name_differs_between_sites(): void {
+		$a = Honeypot::field_name();
+		$this->useSecret( self::SECRET_B );
+
+		$this->assertNotSame( $a, Honeypot::field_name(), 'a shared name is a skip-listable fixed target' );
+	}
+
+	public function test_the_name_is_no_longer_the_fixed_legacy_one(): void {
+		$this->assertNotSame( Honeypot::FIELD, Honeypot::field_name() );
+		$this->assertMatchesRegularExpression( '/^ossg_[0-9a-f]{12}$/', Honeypot::field_name() );
+	}
+
+	public function test_the_rendered_markup_uses_the_derived_name(): void {
+		$this->assertStringContainsString( 'name="' . Honeypot::field_name() . '"', Assets::field_markup() );
+	}
+
+	// --- reading a submission ---------------------------------------------
+
+	public function test_the_derived_name_is_read(): void {
+		$this->assertSame( 'http://spam.example', Honeypot::value_from_request( [ Honeypot::field_name() => 'http://spam.example' ] ) );
+	}
+
+	/** A page cached before this release still submits the old name. */
+	public function test_the_legacy_name_is_still_accepted(): void {
+		$this->assertSame( 'http://spam.example', Honeypot::value_from_request( [ Honeypot::FIELD => 'http://spam.example' ] ) );
+	}
+
+	public function test_an_absent_field_reads_as_empty(): void {
+		$this->assertSame( '', Honeypot::value_from_request( [] ) );
+		$this->assertSame( '', Honeypot::value_from_request( [ Honeypot::field_name() => '' ] ) );
+	}
+
+	/**
+	 * Both names can arrive together: a cached page carries the legacy field
+	 * while the current script injects the derived one. Taking the first key
+	 * *present* rather than the first *filled* would let the empty derived
+	 * field mask a bot that filled the legacy one.
+	 */
+	public function test_a_filled_legacy_field_is_not_masked_by_an_empty_derived_one(): void {
+		$value = Honeypot::value_from_request( [
+			Honeypot::field_name() => '',
+			Honeypot::FIELD        => 'http://spam.example',
+		] );
+
+		$this->assertSame( 'http://spam.example', $value, 'an empty new field must not mask a filled old one' );
+	}
+
+	public function test_a_filled_derived_field_still_wins_when_both_are_filled(): void {
+		$value = Honeypot::value_from_request( [
+			Honeypot::field_name() => 'http://a.example',
+			Honeypot::FIELD        => 'http://b.example',
+		] );
+
+		$this->assertSame( 'http://a.example', $value );
+	}
+
+	// --- end to end --------------------------------------------------------
+
+	public function test_a_bot_filling_either_name_is_blocked_through_the_api(): void {
+		foreach ( [ Honeypot::field_name(), Honeypot::FIELD ] as $name ) {
+			$_POST = [ $name => 'http://spam.example' ];
+
+			$this->assertInstanceOf(
+				WP_Error::class,
+				simple_spam_shield_check( [ 'content' => 'hello' ], 'acme_form' ),
+				"a bot filling {$name} must be blocked"
+			);
+		}
+	}
+}


### PR DESCRIPTION
Closes #23. Last of the 1.4.0 milestone — **this PR also bumps the version to 1.4.0**, so merging it makes the release tag-ready.

## The problem

Every install rendered `simple_spam_shield_website_url`. That made the highest-weight guard a fixed target: a bot author who encountered the plugin once could add that name to a skip-list and defeat the honeypot on every site running it, permanently.

The name is now derived from the site's signing secret as `ossg_<12 hex>`, through a new `Token::derive()` that keeps the secret itself private. Stable for a site — so cached pages and forms already open in a visitor's browser keep working — and unpredictable across sites.

## Only the rendered name changed

The key inside the normalised submission data stays `simple_spam_shield_website_url`. So the guard, the documented `simple_spam_shield_check()` `$fields` contract, and nearly every test are untouched; integrations normalise whichever name arrived onto that key via `Honeypot::value_from_request()`.

The issue predicted ~25 test occurrences would need to become dynamic. In practice **one assertion changed** — the markup test. Keeping the internal key stable is what bought that, and it also means no integrator has to update anything.

## The dual-accept is required, not courteous

The issue treats accepting both names as optional. It isn't. A page cached before this release serves a form carrying the old name, and without the fallback that submission arrives with **no honeypot value at all** — the guard passes rather than blocks. It fails open, silently, for as long as the cache lives.

Two cache-window cases my first draft got wrong, both now covered by tests:

**An empty new field could mask a filled old one.** Reading the first key *present* meant that on a cached page carrying the legacy field plus a fresh script injecting the derived one, a bot filling only the legacy field sailed through. It now takes the first *non-empty* value. The test fails against the `isset()` version:

```
an empty new field must not mask a filled old one
FAILURES! Tests: 1, Assertions: 1, Failures: 1.
```

**`guard.js` injected a second honeypot.** It checked only the derived name before injecting, so on a cached page it appended a new field beside the legacy one — two "website" inputs in one form. It now treats either name as already present, and the form-discovery selector matches both, so server-rendered forms from before the rename are still found and protected.

## Verified live

```
this site renders: ossg_67aa49c9d1f6
legacy name:       simple_spam_shield_website_url

<input type="text" name="ossg_67aa49c9d1f6" id="ossg_67aa49c9d1f6" ...>

derived name               -> BLOCKED (simple_spam_shield_honeypot_failed)
legacy name (cached page)  -> BLOCKED (simple_spam_shield_honeypot_failed)
clean submission           -> allowed

with a different secret:       ossg_4adbdd053c0a
secret restored, name back to: ossg_67aa49c9d1f6
```

The last two lines are the properties that matter: different per site, and stable for a site.

## Gate

| Check | Result |
| --- | --- |
| PHPUnit | 138 tests, 236 assertions (10 new) |
| PHPStan level 5 | no errors |
| PHPCS (WPCS) | clean |
| `bin/check-versions.sh` | consistent at 1.4.0 |
| `bin/check-pot.sh` | up to date, 90 strings |
| Plugin Check (built package) | no errors |

## After merging

1.4.0 is complete: #19, #21 and #23. Ready to tag, which publishes to WordPress.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
